### PR TITLE
닉네임 중복 확인 기능 구현

### DIFF
--- a/src/main/java/me/coonect/coonect/common/security/configuration/SecurityConfiguration.java
+++ b/src/main/java/me/coonect/coonect/common/security/configuration/SecurityConfiguration.java
@@ -16,7 +16,8 @@ public class SecurityConfiguration {
 
   private static final RequestMatcher[] ALLOWED_REQUESTS = {
       new AntPathRequestMatcher("/error", "GET"),
-      new AntPathRequestMatcher("/member", "POST")
+      new AntPathRequestMatcher("/member", "POST"),
+      new AntPathRequestMatcher("/member/nickname/valid", "GET")
   };
 
   @Bean

--- a/src/main/java/me/coonect/coonect/member/adapter/in/NicknameValidationController.java
+++ b/src/main/java/me/coonect/coonect/member/adapter/in/NicknameValidationController.java
@@ -1,0 +1,26 @@
+package me.coonect.coonect.member.adapter.in;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.member.application.port.in.NicknameValidationQuery;
+import me.coonect.coonect.member.application.port.in.NicknameValidationUseCase;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class NicknameValidationController {
+
+  private final NicknameValidationUseCase nicknameValidationUseCase;
+
+  @GetMapping("/member/nickname/valid")
+  public ResponseEntity<Void> validNickname(@RequestParam String nickname) {
+    if (nicknameValidationUseCase.isNicknameDuplicated(NicknameValidationQuery.of(nickname))) {
+      return ResponseEntity.status(HttpServletResponse.SC_CONFLICT).build();
+    }
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/me/coonect/coonect/member/application/domain/service/NicknameValidationService.java
+++ b/src/main/java/me/coonect/coonect/member/application/domain/service/NicknameValidationService.java
@@ -1,0 +1,21 @@
+package me.coonect.coonect.member.application.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.member.application.port.in.NicknameValidationQuery;
+import me.coonect.coonect.member.application.port.in.NicknameValidationUseCase;
+import me.coonect.coonect.member.application.port.out.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class NicknameValidationService implements NicknameValidationUseCase {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public boolean isNicknameDuplicated(NicknameValidationQuery query) {
+    return memberRepository.existsByNickname(query.getNickname());
+  }
+}

--- a/src/main/java/me/coonect/coonect/member/application/port/in/NicknameValidationQuery.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/NicknameValidationQuery.java
@@ -1,0 +1,22 @@
+package me.coonect.coonect.member.application.port.in;
+
+import lombok.Getter;
+import me.coonect.coonect.common.validation.Validator;
+import me.coonect.coonect.member.application.port.in.validation.Nickname;
+
+@Getter
+public class NicknameValidationQuery {
+
+  @Nickname
+  private final String nickname;
+
+  private NicknameValidationQuery(String nickname) {
+    this.nickname = nickname;
+
+    Validator.validate(this);
+  }
+
+  public static NicknameValidationQuery of(String nickname) {
+    return new NicknameValidationQuery(nickname);
+  }
+}

--- a/src/main/java/me/coonect/coonect/member/application/port/in/NicknameValidationUseCase.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/NicknameValidationUseCase.java
@@ -1,0 +1,6 @@
+package me.coonect.coonect.member.application.port.in;
+
+public interface NicknameValidationUseCase {
+
+  boolean isNicknameDuplicated(NicknameValidationQuery query);
+}

--- a/src/test/java/me/coonect/coonect/member/adapter/in/NicknameValidationControllerTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/NicknameValidationControllerTest.java
@@ -1,0 +1,67 @@
+package me.coonect.coonect.member.adapter.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import me.coonect.coonect.member.application.domain.model.Member;
+import me.coonect.coonect.member.application.port.out.MemberRepository;
+import me.coonect.coonect.mock.TestContainer;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NicknameValidationControllerTest {
+
+  private NicknameValidationController nicknameValidationController;
+  private MemberRepository memberRepository;
+
+  @Test
+  public void 닉네임이_겹치면_409_응답을_내린다() throws Exception {
+    // given
+    TestContainer testContainer = TestContainer.builder().build();
+
+    nicknameValidationController = testContainer.nicknameValidationController;
+    memberRepository = testContainer.memberRepository;
+
+    memberRepository.save(Member.withoutId("duk9741@gmail.com",
+        "@12cdefghijkl",
+        "dukcode",
+        LocalDate.of(1995, 1, 10)));
+
+    String nickname = "dukcode";
+
+    // when
+    ResponseEntity<Void> result = nicknameValidationController.validNickname(nickname);
+
+    // then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(409));
+    assertThat(result.getBody()).isNull();
+  }
+
+  @Test
+  public void 닉네임이_겹치지_않으면_200_응답을_내린다() throws Exception {
+    // given
+    TestContainer testContainer = TestContainer.builder().build();
+
+    nicknameValidationController = testContainer.nicknameValidationController;
+    memberRepository = testContainer.memberRepository;
+
+    memberRepository.save(Member.withoutId("duk9741@gmail.com",
+        "@12cdefghijkl",
+        "dukcode",
+        LocalDate.of(1995, 1, 10)));
+
+    String nickname = "newname";
+
+    // when
+    ResponseEntity<Void> result = nicknameValidationController.validNickname(nickname);
+
+    // then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+    assertThat(result.getBody()).isNull();
+  }
+
+}

--- a/src/test/java/me/coonect/coonect/member/application/domain/service/NicknameValidationServiceTest.java
+++ b/src/test/java/me/coonect/coonect/member/application/domain/service/NicknameValidationServiceTest.java
@@ -1,0 +1,59 @@
+package me.coonect.coonect.member.application.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import me.coonect.coonect.member.application.domain.model.Member;
+import me.coonect.coonect.member.application.port.in.NicknameValidationQuery;
+import me.coonect.coonect.member.application.port.in.NicknameValidationUseCase;
+import me.coonect.coonect.member.application.port.out.MemberRepository;
+import me.coonect.coonect.mock.FakeMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NicknameValidationServiceTest {
+
+  private NicknameValidationUseCase nicknameValidationUseCase;
+
+  @BeforeEach
+  public void init() {
+    MemberRepository memberRepository = new FakeMemberRepository();
+    nicknameValidationUseCase = new NicknameValidationService(memberRepository);
+
+    Member member = Member.withoutId("duk9741@gmail.com",
+        "@12cdefghijkl",
+        "dukcode",
+        LocalDate.of(1995, 1, 10));
+
+    memberRepository.save(member);
+  }
+
+  @Test
+  public void 중복된_값을_요청하면_true_를_반환한다() throws Exception {
+    // given
+    String nickname = "dukcode";
+
+    // when
+    boolean result = nicknameValidationUseCase.isNicknameDuplicated(
+        NicknameValidationQuery.of(nickname));
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void 새로운_값을_요청하면_false_를_반환한다() throws Exception {
+    // given
+    String nickname = "xxxxxxx";
+
+    // when
+    boolean result = nicknameValidationUseCase.isNicknameDuplicated(
+        NicknameValidationQuery.of(nickname));
+
+    // then
+    assertThat(result).isFalse();
+  }
+}

--- a/src/test/java/me/coonect/coonect/member/application/port/in/NicknameValidationQueryTest.java
+++ b/src/test/java/me/coonect/coonect/member/application/port/in/NicknameValidationQueryTest.java
@@ -1,0 +1,44 @@
+package me.coonect.coonect.member.application.port.in;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NicknameValidationQueryTest {
+
+  @Test
+  public void nickname_규칙을_지키면_생성할_수_있다() throws Exception {
+    // given
+    String nickname = "가나다asd";
+
+    // when
+    Throwable throwable = catchThrowable(() ->
+        NicknameValidationQuery.of(nickname)
+    );
+
+    // then
+    assertThat(throwable).isNull();
+
+  }
+
+  @Test
+  public void nickname_규칙을_지키지_않으면_생성할_수_없다() throws Exception {
+    // given
+    String nickname = "가ㅏㅏ_jj";
+
+    // when
+    // then
+    assertThatThrownBy(() ->
+        NicknameValidationQuery.of(nickname))
+        .isInstanceOf(ConstraintViolationException.class)
+        .hasMessageContaining("nickname");
+
+  }
+
+}

--- a/src/test/java/me/coonect/coonect/mock/TestContainer.java
+++ b/src/test/java/me/coonect/coonect/mock/TestContainer.java
@@ -2,8 +2,11 @@ package me.coonect.coonect.mock;
 
 import lombok.Builder;
 import me.coonect.coonect.member.adapter.in.MemberSignupController;
+import me.coonect.coonect.member.adapter.in.NicknameValidationController;
 import me.coonect.coonect.member.application.domain.service.MemberSignupService;
+import me.coonect.coonect.member.application.domain.service.NicknameValidationService;
 import me.coonect.coonect.member.application.port.in.MemberSignupUseCase;
+import me.coonect.coonect.member.application.port.in.NicknameValidationUseCase;
 import me.coonect.coonect.member.application.port.out.MemberRepository;
 
 public class TestContainer {
@@ -11,15 +14,19 @@ public class TestContainer {
   public MemberRepository memberRepository;
 
   public MemberSignupUseCase memberSignupUseCase;
+  public NicknameValidationUseCase nicknameValidationUseCase;
 
   public MemberSignupController memberSignupController;
+  public NicknameValidationController nicknameValidationController;
 
   @Builder
   public TestContainer() {
     memberRepository = new FakeMemberRepository();
 
     memberSignupUseCase = new MemberSignupService(memberRepository);
+    nicknameValidationUseCase = new NicknameValidationService(memberRepository);
 
     memberSignupController = new MemberSignupController(memberSignupUseCase);
+    nicknameValidationController = new NicknameValidationController(nicknameValidationUseCase);
   }
 }


### PR DESCRIPTION
## 작업 내용

닉네임 중복을 확인하는 API를 구현

## 핵심 변경 사항

- UseCase 전용 `NicknameValidationQuery` 구현
  - 생성자에서 nickname 형식 Validation 수행

## 테스트 결과

- 43개 테스트 모두 통과

![image](https://github.com/coonect-projects/coonect-api/assets/59705184/6749c0d8-9e65-4bee-b576-ca5db6491fcc)

- 메서드 커버리지 82%, 라인 커버리지 80% 달성

![image](https://github.com/coonect-projects/coonect-api/assets/59705184/ee368da1-6b3a-4131-8a15-d2169b02c7ad)

## 닫힌 이슈

close #2 

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
