### PR TITLE
회원 가입 시 인증 코드 검증 로직 추가

### DIFF
--- a/src/main/java/me/coonect/coonect/common/error/exception/ErrorCode.java
+++ b/src/main/java/me/coonect/coonect/common/error/exception/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
 
   // Member
   EMAIL_DUPLICATE(SC_CONFLICT, "M-001", "Duplicate Email Address"),
-  NICKNAME_DUPLICATE(SC_CONFLICT, "M-002", "Duplicate Nickname");
+  NICKNAME_DUPLICATE(SC_CONFLICT, "M-002", "Duplicate Nickname"),
+  VERIFIED_EMAIL_NOT_FOUND(SC_NOT_FOUND, "M-003", "Verified Email Not Found");
 
   private final String code;
   private final String message;

--- a/src/main/java/me/coonect/coonect/common/error/exception/NotFoundException.java
+++ b/src/main/java/me/coonect/coonect/common/error/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package me.coonect.coonect.common.error.exception;
+
+public class NotFoundException extends BusinessException {
+
+  public NotFoundException() {
+    super(ErrorCode.NOT_FOUND.getMessage(), ErrorCode.NOT_FOUND);
+  }
+
+  public NotFoundException(ErrorCode errorCode) {
+    super(errorCode.getMessage(), errorCode);
+  }
+}

--- a/src/main/java/me/coonect/coonect/member/adapter/in/web/dto/request/MemberSignupRequest.java
+++ b/src/main/java/me/coonect/coonect/member/adapter/in/web/dto/request/MemberSignupRequest.java
@@ -14,12 +14,14 @@ import me.coonect.coonect.member.application.port.in.model.MemberSignupCommand;
 public class MemberSignupRequest {
 
   private String email;
+
+  private String emailVerificationCode;
   private String password;
   private String nickname;
   private LocalDate birthday;
 
   public MemberSignupCommand toCommand() {
-    return new MemberSignupCommand(email, password, nickname, birthday);
+    return new MemberSignupCommand(email, emailVerificationCode, password, nickname, birthday);
   }
 
 }

--- a/src/main/java/me/coonect/coonect/member/adapter/out/persistence/VerifiedEmailRedisRepository.java
+++ b/src/main/java/me/coonect/coonect/member/adapter/out/persistence/VerifiedEmailRedisRepository.java
@@ -1,5 +1,6 @@
 package me.coonect.coonect.member.adapter.out.persistence;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import me.coonect.coonect.member.application.port.out.persistence.VerifiedEmailRepository;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -15,24 +16,24 @@ public class VerifiedEmailRedisRepository implements VerifiedEmailRepository {
   private final StringRedisTemplate redisTemplate;
 
   @Override
-  public void save(String code, String email) {
+  public void save(String email, String code, Duration expireDuration) {
     ValueOperations<String, String> ops = redisTemplate.opsForValue();
-    ops.set(KEY_PREFIX + code, email);
+    ops.set(KEY_PREFIX + email, code);
   }
 
   @Override
-  public String get(String code) {
+  public String get(String email) {
     ValueOperations<String, String> ops = redisTemplate.opsForValue();
-    return ops.get(KEY_PREFIX + code);
+    return ops.get(KEY_PREFIX + email);
   }
 
   @Override
-  public void remove(String code) {
-    redisTemplate.delete(KEY_PREFIX + code);
+  public void remove(String email) {
+    redisTemplate.delete(KEY_PREFIX + email);
   }
 
   @Override
-  public boolean has(String code) {
-    return redisTemplate.hasKey(KEY_PREFIX + code);
+  public boolean has(String email) {
+    return redisTemplate.hasKey(KEY_PREFIX + email);
   }
 }

--- a/src/main/java/me/coonect/coonect/member/application/domain/service/EmailVerificationService.java
+++ b/src/main/java/me/coonect/coonect/member/application/domain/service/EmailVerificationService.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 import me.coonect.coonect.common.error.exception.BusinessException;
 import me.coonect.coonect.common.error.exception.ErrorCode;
 import me.coonect.coonect.member.application.domain.exception.EmailDuplicationException;
-import me.coonect.coonect.member.application.port.in.model.EmailVerificationConfirmCommand;
 import me.coonect.coonect.member.application.port.in.EmailVerificationUseCase;
+import me.coonect.coonect.member.application.port.in.model.EmailVerificationConfirmCommand;
 import me.coonect.coonect.member.application.port.in.model.SendVerificationEmailCommand;
 import me.coonect.coonect.member.application.port.out.infrastructure.EmailVerificationCodeGenerator;
 import me.coonect.coonect.member.application.port.out.infrastructure.EmailVerificationMailSender;
@@ -30,6 +30,9 @@ public class EmailVerificationService implements EmailVerificationUseCase {
   private final VerifiedEmailRepository verifiedEmailRepository;
   @Value("${coonect.email.verification.expire-minute}")
   private int emailVerificationExpireMinute;
+
+  @Value("${coonect.email.verified.expire-minute}")
+  private int verifiedEmailExpireMinute;
 
   @Override
   public void sendVerificationEmail(SendVerificationEmailCommand command) {
@@ -56,7 +59,7 @@ public class EmailVerificationService implements EmailVerificationUseCase {
     checkEmailDuplicated(email);
 
     if (isVerify(email, code)) {
-      verifiedEmailRepository.save(code, email);
+      verifiedEmailRepository.save(email, code, Duration.ofMinutes(verifiedEmailExpireMinute));
       emailVerificationCodeRepository.remove(email);
       return true;
     }

--- a/src/main/java/me/coonect/coonect/member/application/domain/service/MemberSignupService.java
+++ b/src/main/java/me/coonect/coonect/member/application/domain/service/MemberSignupService.java
@@ -40,10 +40,11 @@ public class MemberSignupService implements MemberSignupUseCase {
       throw new NotFoundException(ErrorCode.VERIFIED_EMAIL_NOT_FOUND);
     }
 
+    verifiedEmailRepository.remove(email);
     return memberRepository.save(command.toMember());
   }
 
   private boolean verifyCode(String email, String code) {
-    return verifiedEmailRepository.has(code) && verifiedEmailRepository.get(code).equals(email);
+    return verifiedEmailRepository.has(email) && verifiedEmailRepository.get(email).equals(code);
   }
 }

--- a/src/main/java/me/coonect/coonect/member/application/domain/service/MemberSignupService.java
+++ b/src/main/java/me/coonect/coonect/member/application/domain/service/MemberSignupService.java
@@ -1,12 +1,15 @@
 package me.coonect.coonect.member.application.domain.service;
 
 import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.common.error.exception.ErrorCode;
+import me.coonect.coonect.common.error.exception.NotFoundException;
 import me.coonect.coonect.member.application.domain.exception.EmailDuplicationException;
 import me.coonect.coonect.member.application.domain.exception.NicknameDuplicationException;
 import me.coonect.coonect.member.application.domain.model.Member;
-import me.coonect.coonect.member.application.port.in.model.MemberSignupCommand;
 import me.coonect.coonect.member.application.port.in.MemberSignupUseCase;
+import me.coonect.coonect.member.application.port.in.model.MemberSignupCommand;
 import me.coonect.coonect.member.application.port.out.persistence.MemberRepository;
+import me.coonect.coonect.member.application.port.out.persistence.VerifiedEmailRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,20 +19,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberSignupService implements MemberSignupUseCase {
 
   private final MemberRepository memberRepository;
+  private final VerifiedEmailRepository verifiedEmailRepository;
 
   @Transactional
   @Override
   public Member signup(final MemberSignupCommand command) {
-    if (memberRepository.existsByEmail(command.getEmail())) {
-      throw new EmailDuplicationException(command.getEmail());
+    String email = command.getEmail();
+    String nickname = command.getNickname();
+    String code = command.getEmailVerificationCode();
+
+    if (memberRepository.existsByEmail(email)) {
+      throw new EmailDuplicationException(email);
     }
 
-    if (memberRepository.existsByNickname(command.getNickname())) {
-      throw new NicknameDuplicationException(command.getNickname());
+    if (memberRepository.existsByNickname(nickname)) {
+      throw new NicknameDuplicationException(nickname);
     }
 
-    // TODO: VerifiedEmailRepository 에 코드 및 이메일 존재 확인 후 가입 진행
+    if (!verifyCode(email, code)) {
+      throw new NotFoundException(ErrorCode.VERIFIED_EMAIL_NOT_FOUND);
+    }
 
     return memberRepository.save(command.toMember());
+  }
+
+  private boolean verifyCode(String email, String code) {
+    return verifiedEmailRepository.has(code) && verifiedEmailRepository.get(code).equals(email);
   }
 }

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommand.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommand.java
@@ -18,6 +18,8 @@ public class MemberSignupCommand {
   @NotBlank(message = "email은 공백일 수 없습니다.")
   private final String email;
 
+  private final String emailVerificationCode;
+
   @Password
   private final String password;
 
@@ -28,8 +30,10 @@ public class MemberSignupCommand {
   @NotNull(message = "birthday는 null일 수 없습니다.")
   private final LocalDate birthday;
 
-  public MemberSignupCommand(String email, String password, String nickname, LocalDate birthday) {
+  public MemberSignupCommand(String email, String emailVerificationCode, String password,
+      String nickname, LocalDate birthday) {
     this.email = email;
+    this.emailVerificationCode = emailVerificationCode;
     this.password = password;
     this.nickname = nickname;
     this.birthday = birthday;

--- a/src/main/java/me/coonect/coonect/member/application/port/out/persistence/VerifiedEmailRepository.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/out/persistence/VerifiedEmailRepository.java
@@ -1,12 +1,14 @@
 package me.coonect.coonect.member.application.port.out.persistence;
 
+import java.time.Duration;
+
 public interface VerifiedEmailRepository {
 
-  void save(String code, String email);
+  void save(String email, String code, Duration expireDuration);
 
-  String get(String code);
+  String get(String email);
 
-  void remove(String code);
+  void remove(String email);
 
-  boolean has(String code);
+  boolean has(String email);
 }

--- a/src/test/java/me/coonect/coonect/member/adapter/in/web/MemberSignupControllerTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/web/MemberSignupControllerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import me.coonect.coonect.member.adapter.in.web.dto.request.MemberSignupRequest;
 import me.coonect.coonect.member.adapter.in.web.dto.response.MemberResponse;
+import me.coonect.coonect.member.application.port.out.persistence.VerifiedEmailRepository;
 import me.coonect.coonect.mock.TestContainer;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -21,8 +22,12 @@ class MemberSignupControllerTest {
     TestContainer testContainer = TestContainer.builder().build();
 
     MemberSignupController memberSignupController = testContainer.memberSignupController;
+    VerifiedEmailRepository verifiedEmailRepository = testContainer.verifiedEmailRepository;
+
+    verifiedEmailRepository.save("123456", "duk9741@gmail.com");
 
     MemberSignupRequest request = new MemberSignupRequest("duk9741@gmail.com",
+        "123456",
         "!@#qwe123",
         "닉네임",
         LocalDate.of(1995, 1, 10));

--- a/src/test/java/me/coonect/coonect/member/adapter/in/web/MemberSignupControllerTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/web/MemberSignupControllerTest.java
@@ -2,6 +2,7 @@ package me.coonect.coonect.member.adapter.in.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import me.coonect.coonect.member.adapter.in.web.dto.request.MemberSignupRequest;
 import me.coonect.coonect.member.adapter.in.web.dto.response.MemberResponse;
@@ -24,7 +25,7 @@ class MemberSignupControllerTest {
     MemberSignupController memberSignupController = testContainer.memberSignupController;
     VerifiedEmailRepository verifiedEmailRepository = testContainer.verifiedEmailRepository;
 
-    verifiedEmailRepository.save("123456", "duk9741@gmail.com");
+    verifiedEmailRepository.save("duk9741@gmail.com", "123456", Duration.ZERO);
 
     MemberSignupRequest request = new MemberSignupRequest("duk9741@gmail.com",
         "123456",

--- a/src/test/java/me/coonect/coonect/member/adapter/in/web/dto/request/MemberSignupRequestTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/web/dto/request/MemberSignupRequestTest.java
@@ -15,6 +15,7 @@ class MemberSignupRequestTest {
   public void MemberSignupRequest_는_MemberSignupCommand_로_변환될_수_있다() throws Exception {
     // given
     MemberSignupRequest request = new MemberSignupRequest("duk9741@gmail.com",
+        "123456",
         "!@#qwe123",
         "닉네임",
         LocalDate.of(1995, 1, 10));

--- a/src/test/java/me/coonect/coonect/member/application/domain/service/EmailVerificationServiceTest.java
+++ b/src/test/java/me/coonect/coonect/member/application/domain/service/EmailVerificationServiceTest.java
@@ -138,8 +138,8 @@ class EmailVerificationServiceTest {
     // then
     assertThat(result).isTrue();
     assertThat(emailVerificationCodeRepository.has(email)).isFalse();
-    assertThat(verifiedEmailRepository.has(code)).isTrue();
-    assertThat(verifiedEmailRepository.get(code)).isEqualTo(email);
+    assertThat(verifiedEmailRepository.has(email)).isTrue();
+    assertThat(verifiedEmailRepository.get(email)).isEqualTo(code);
 
   }
 
@@ -158,6 +158,6 @@ class EmailVerificationServiceTest {
 
     // then
     assertThat(result).isFalse();
-    assertThat(verifiedEmailRepository.has(code)).isFalse();
+    assertThat(verifiedEmailRepository.has(email)).isFalse();
   }
 }

--- a/src/test/java/me/coonect/coonect/member/application/domain/service/MemberSignupServiceTest.java
+++ b/src/test/java/me/coonect/coonect/member/application/domain/service/MemberSignupServiceTest.java
@@ -3,6 +3,7 @@ package me.coonect.coonect.member.application.domain.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import me.coonect.coonect.common.error.exception.NotFoundException;
 import me.coonect.coonect.member.application.domain.exception.EmailDuplicationException;
@@ -35,7 +36,7 @@ class MemberSignupServiceTest {
   @Test
   public void 회원가입이_가능하다() throws Exception {
     // given
-    verifiedEmailRepository.save("123456", "duk9741@gmail.com");
+    verifiedEmailRepository.save("duk9741@gmail.com", "123456", Duration.ZERO);
 
     MemberSignupCommand memberSignupCommand = new MemberSignupCommand("duk9741@gmail.com",
         "123456", "@12cdefghijkl",
@@ -58,7 +59,7 @@ class MemberSignupServiceTest {
     // given
     String code = "123456";
     String differentCode = "000000";
-    verifiedEmailRepository.save(code, "duk9741@gmail.com");
+    verifiedEmailRepository.save("duk9741@gmail.com", code, Duration.ZERO);
 
     MemberSignupCommand memberSignupCommand = new MemberSignupCommand("duk9741@gmail.com",
         differentCode, "@12cdefghijkl",
@@ -109,5 +110,51 @@ class MemberSignupServiceTest {
     // then
     assertThatThrownBy(() -> memberSignupService.signup(memberSignupCommand))
         .isInstanceOf(NicknameDuplicationException.class);
+  }
+
+  @Test
+  public void 회원_가입_후_저장된_인증_번호는_삭제된다() throws Exception {
+    // given
+    String code = "123456";
+    String email = "dukcode@gmail.com";
+
+    verifiedEmailRepository.save(email, code, Duration.ZERO);
+
+    MemberSignupCommand command = new MemberSignupCommand(email,
+        code, "@12cdefghijkl",
+        "dukcode",
+        LocalDate.of(1995, 1, 10));
+
+    // when
+    Member member = memberSignupService.signup(command);
+
+    // then
+    assertThat(member.getId()).isNotNull();
+    assertThat(verifiedEmailRepository.has(email)).isFalse();
+  }
+
+  @Test
+  public void 두_사용자가_같은_인증_번호를_받고_인증_후_동시에_회원_가입_할_수_있다() throws Exception {
+    // given
+    String code = "123456";
+    verifiedEmailRepository.save("dukcode1@gmail.com", code, Duration.ZERO);
+    verifiedEmailRepository.save("dukcode2@gmail.com", code, Duration.ZERO);
+
+    MemberSignupCommand command1 = new MemberSignupCommand("dukcode1@gmail.com",
+        code, "@12cdefghijkl",
+        "dukcode1",
+        LocalDate.of(1995, 1, 10));
+    MemberSignupCommand command2 = new MemberSignupCommand("dukcode2@gmail.com",
+        code, "@12cdefghijkl",
+        "dukcode2",
+        LocalDate.of(1995, 1, 10));
+
+    // when
+    Member member1 = memberSignupService.signup(command1);
+    Member member2 = memberSignupService.signup(command2);
+
+    // then
+    assertThat(member1.getId()).isNotNull();
+    assertThat(member2.getId()).isNotNull();
   }
 }

--- a/src/test/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommandTest.java
+++ b/src/test/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommandTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import jakarta.validation.ConstraintViolationException;
 import java.time.LocalDate;
 import me.coonect.coonect.member.application.domain.model.Member;
-import me.coonect.coonect.member.application.port.in.model.MemberSignupCommand;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,7 @@ class MemberSignupCommandTest {
     // when
     Throwable throwable = catchThrowable(() -> {
       new MemberSignupCommand("duk9741@gmail.com",
-          "@12cdefghijkl",
+          "123456", "@12cdefghijkl",
           "dukcode",
           LocalDate.of(1995, 1, 10));
     });
@@ -36,7 +35,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("xxxxxxxxxxxxx",
-            "1a!4567890",
+            "123456", "1a!4567890",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -49,7 +48,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("      ",
-            "1a!4567890",
+            "123456", "1a!4567890",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -62,7 +61,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand(null,
-            "1a!4567890",
+            "123456", "1a!4567890",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -75,7 +74,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "1a!4567",
+            "123456", "1a!4567",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -88,7 +87,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "1a!456789012345678901",
+            "123456", "1a!456789012345678901",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -101,7 +100,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "!234567890",
+            "123456", "!234567890",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -114,7 +113,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "!bcdefghijkl",
+            "123456", "!bcdefghijkl",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -127,7 +126,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "12cdefghijkl",
+            "123456", "12cdefghijkl",
             "dukcode",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -140,7 +139,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "12cdefghijkl",
+            "123456", "12cdefghijkl",
             "d",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -153,7 +152,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "12cdefghijkl",
+            "123456", "12cdefghijkl",
             "12345678901",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -166,7 +165,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "a   a",
+            "123456", "a   a",
             "12345678901",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -180,7 +179,7 @@ class MemberSignupCommandTest {
     // then
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "@12cdefghijkl",
+            "123456", "@12cdefghijkl",
             "김ㅁㅁ",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -193,7 +192,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "@12cdefghijkl",
+            "123456", "@12cdefghijkl",
             "김ㅏㅏ",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -206,7 +205,7 @@ class MemberSignupCommandTest {
     // when
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "@12cdefghijkl",
+            "123456", "@12cdefghijkl",
             "김@@#",
             LocalDate.of(1995, 1, 10))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -220,7 +219,7 @@ class MemberSignupCommandTest {
     // then
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "@12cdefghijkl",
+            "123456", "@12cdefghijkl",
             "dukcode",
             null)
     ).isInstanceOf(ConstraintViolationException.class)
@@ -234,7 +233,7 @@ class MemberSignupCommandTest {
     // then
     assertThatThrownBy(() ->
         new MemberSignupCommand("duk9741@gmail.com",
-            "@12cdefghijkl",
+            "123456", "@12cdefghijkl",
             "dukcode",
             LocalDate.now().plusDays(1))
     ).isInstanceOf(ConstraintViolationException.class)
@@ -247,7 +246,7 @@ class MemberSignupCommandTest {
     MemberSignupCommand memberSignupCommand
 
         = new MemberSignupCommand("duk9741@gmail.com",
-        "@12cdefghijkl",
+        "123456", "@12cdefghijkl",
         "dukcode",
         LocalDate.of(1995, 1, 10));
     // when

--- a/src/test/java/me/coonect/coonect/mock/FakeVerifiedEmailRepository.java
+++ b/src/test/java/me/coonect/coonect/mock/FakeVerifiedEmailRepository.java
@@ -1,5 +1,6 @@
 package me.coonect.coonect.mock;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import me.coonect.coonect.member.application.port.out.persistence.VerifiedEmailRepository;
@@ -9,22 +10,22 @@ public class FakeVerifiedEmailRepository implements VerifiedEmailRepository {
   private Map<String, String> data = new HashMap<>();
 
   @Override
-  public void save(String code, String email) {
-    data.put(code, email);
+  public void save(String email, String code, Duration expireDuration) {
+    data.put(email, code);
   }
 
   @Override
-  public String get(String code) {
-    return data.get(code);
+  public String get(String email) {
+    return data.get(email);
   }
 
   @Override
-  public void remove(String code) {
-    data.remove(code);
+  public void remove(String email) {
+    data.remove(email);
   }
 
   @Override
-  public boolean has(String code) {
-    return data.containsKey(code);
+  public boolean has(String email) {
+    return data.containsKey(email);
   }
 }

--- a/src/test/java/me/coonect/coonect/mock/TestContainer.java
+++ b/src/test/java/me/coonect/coonect/mock/TestContainer.java
@@ -41,7 +41,7 @@ public class TestContainer {
     emailVerificationCodeRepository = new FakeEmailVerificationCodeRepository();
     verifiedEmailRepository = new FakeVerifiedEmailRepository();
 
-    memberSignupUseCase = new MemberSignupService(memberRepository);
+    memberSignupUseCase = new MemberSignupService(memberRepository, verifiedEmailRepository);
     nicknameValidationUseCase = new NicknameValidationService(memberRepository);
     emailVerificationUseCase = new EmailVerificationService(memberRepository,
         emailVerificationMailSender,


### PR DESCRIPTION
## 작업 내용

- 회원 가입 시 인증 받은 코드가 존재 하는 지 확인 후 가입 진행

## 핵심 변경 사항

- #12 에서 고려사항인 **두 사용자가 같은 인증 코드를 받았을 때 동시에 가입**이 가능 하도록 `VerifiedEmailRepository`의 key 속성과 value 속성을 **code -> email**에서 **email -> code**로 변경
- `VerifiedEmailRepository`에서 인증 완료 후 가입 가능 시간 설정 추가

## 테스트 결과

- 테스트 67개 모두 통과

![image](https://github.com/coonect-projects/coonect-api/assets/59705184/3235f497-9057-45e5-b755-e5d8b536ec60)

- 클래스 커버리지 100%, 메서드 커버리지 76%, 라인 커버리지 74% 달성

![image](https://github.com/coonect-projects/coonect-api/assets/59705184/1d343fca-7d75-4cbb-8b9e-a753bfe7fa27)

## 닫힌 이슈

close #11 

