### PR TITLE
Spring REST Docs 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ out/
 ### VS Code ###
 .vscode/
 /src/main/resources/application-local.yml
+/src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ java {
 }
 
 configurations {
+    asciidoctorExt
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -38,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -58,9 +60,26 @@ dependencyManagement {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy asciidoctor
 }
 
 tasks.named('asciidoctor') {
-    inputs.dir snippetsDir
     dependsOn test
+    configurations 'asciidoctorExt'
+    inputs.dir snippetsDir
+    finalizedBy copyDocument
+    doFirst {
+        delete file('src/main/resources/static/docs')
+    }
+
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from file('build/docs/asciidoc')
+    into file('src/main/resources/static/docs')
+}
+
+bootJar {
+    dependsOn asciidoctor
 }

--- a/build.gradle
+++ b/build.gradle
@@ -91,4 +91,10 @@ tasks.register('copyDocument', Copy) {
 
 bootJar {
     dependsOn asciidoctor
+    doFirst {
+        delete file('static/docs')
+    }
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,12 @@ dependencyManagement {
     }
 }
 
+tasks.named('testClasses') {
+    doFirst {
+        delete file('build/docs/asciidoc')
+    }
+}
+
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
@@ -67,11 +73,14 @@ tasks.named('asciidoctor') {
     dependsOn test
     configurations 'asciidoctorExt'
     inputs.dir snippetsDir
-    finalizedBy copyDocument
     doFirst {
         delete file('src/main/resources/static/docs')
     }
-
+    sources {
+        include("*.adoc")
+    }
+    finalizedBy copyDocument
+    baseDirFollowsSourceFile()
 }
 
 tasks.register('copyDocument', Copy) {

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -3,108 +3,21 @@
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 2
+:toclevels: 3
 
-== Member 관련 API
+== 인증 메일 전송 요청
 
-=== 인증 메일 전송 요청
+include::{docdir}/member/sendVerificationMail.adoc[]
 
-회원 가입을 위한 이메일 인증 메일 전송을 요청합니다.
+== 인증 번호 확인 요청
 
-==== 요청
+include::{docdir}/member/confirmEmailVerification.adoc[]
 
-include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-request.adoc[]
+== 닉네임 중복 검사
 
-==== 응답
+include::{docdir}/member/validateNickname.adoc[]
 
-인증 메일 전송 성공 시 응답
+== 회원 가입
 
-include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-response.adoc[]
+include::{docdir}/member/signup.adoc[]
 
-===== 중복된 이메일로 요청 시 에러 응답
-
-이미 가입된 이메일로 가입할 수 없습니다.
-
-include::{snippets}/email-verification-controller-test/send-verification-mail_409/http-response.adoc[]
-
-===== 메일 전송 실패 시 에러 응답
-
-존재하지 않는 메일로 메일을 전송할 수 없습니다.
-
-include::{snippets}/email-verification-controller-test/send-verification-mail_400/http-response.adoc[]
-
-=== 닉네임 중복 검사
-
-이미 가입된 닉네임인지 검증을 요청합니다.
-
-==== 요청 쿼리 파라미터
-
-include::{snippets}/nickname-validation-controller-test/validate-nickname_200/query-parameters.adoc[]
-
-==== 요청
-
-include::{snippets}/nickname-validation-controller-test/validate-nickname_200/http-request.adoc[]
-
-==== 응답
-
-사용 가능한 닉네임일 시 응답
-
-include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-response.adoc[]
-
-===== 중복된 닉네임으로 요청 시 에러 응답
-
-이미 가입된 닉네임으로 가입할 수 없습니다.
-
-include::{snippets}/nickname-validation-controller-test/validate-nickname_409/http-response.adoc[]
-
-===== 유효성 조건을 통과하지 못한 닉네임으로 요청 시
-
-닉네임 constraints를 만족해야 합니다.
-
-include::{snippets}/nickname-validation-controller-test/validate-nickname_400_validation/http-response.adoc[]
-
-=== 회원 가입
-
-회원 정보를 통해 회원 가입을 진행합니다.
-
-==== 요청 필드
-
-include::{snippets}/member-signup-controller-test/signup_201/request-fields.adoc[]
-
-==== 요청
-
-include::{snippets}/member-signup-controller-test/signup_201/http-request.adoc[]
-
-==== 응답 필드
-
-include::{snippets}/member-signup-controller-test/signup_201/response-fields.adoc[]
-
-==== 응답
-
-회원 가입 성공 시 응답
-
-include::{snippets}/member-signup-controller-test/signup_201/http-response.adoc[]
-
-===== 입력 유효성 체크 실패 시 응답
-
-요청 필드가 제약 조건을 지켜야 합니다.
-
-include::{snippets}/member-signup-controller-test/signup_400_invalid_input/http-response.adoc[]
-
-===== 이메일 미인증 시 응답
-
-이메일 인증을 받은 후에 회원 가입 요청을 진행해야 합니다. 요청 확인 후 회원 가입 유효 기간은 60분 입니다.
-
-include::{snippets}/member-signup-controller-test/signup_400_verified_email_not_found/http-response.adoc[]
-
-===== 이메일 중복 시 응답
-
-중복된 이메일로 가입할 수 없습니다.
-
-include::{snippets}/member-signup-controller-test/signup_409_email/http-response.adoc[]
-
-===== 닉네임 중복 시 응답
-
-중복된 닉네임으로 가입할 수 없습니다.
-
-include::{snippets}/member-signup-controller-test/signup_409_nickname/http-response.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,9 +1,9 @@
-= Coonect API Document
+= Member API Document
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 3
+:toclevels: 2
 
 == 인증 메일 전송 요청
 

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,110 @@
+= Coonect API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== Member 관련 API
+
+=== 인증 메일 전송 요청
+
+회원 가입을 위한 이메일 인증 메일 전송을 요청합니다.
+
+==== 요청
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-request.adoc[]
+
+==== 응답
+
+인증 메일 전송 성공 시 응답
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-response.adoc[]
+
+===== 중복된 이메일로 요청 시 에러 응답
+
+이미 가입된 이메일로 가입할 수 없습니다.
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_409/http-response.adoc[]
+
+===== 메일 전송 실패 시 에러 응답
+
+존재하지 않는 메일로 메일을 전송할 수 없습니다.
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_400/http-response.adoc[]
+
+=== 닉네임 중복 검사
+
+이미 가입된 닉네임인지 검증을 요청합니다.
+
+==== 요청 쿼리 파라미터
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_200/query-parameters.adoc[]
+
+==== 요청
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_200/http-request.adoc[]
+
+==== 응답
+
+사용 가능한 닉네임일 시 응답
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-response.adoc[]
+
+===== 중복된 닉네임으로 요청 시 에러 응답
+
+이미 가입된 닉네임으로 가입할 수 없습니다.
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_409/http-response.adoc[]
+
+===== 유효성 조건을 통과하지 못한 닉네임으로 요청 시
+
+닉네임 constraints를 만족해야 합니다.
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_400_validation/http-response.adoc[]
+
+=== 회원 가입
+
+회원 정보를 통해 회원 가입을 진행합니다.
+
+==== 요청 필드
+
+include::{snippets}/member-signup-controller-test/signup_201/request-fields.adoc[]
+
+==== 요청
+
+include::{snippets}/member-signup-controller-test/signup_201/http-request.adoc[]
+
+==== 응답 필드
+
+include::{snippets}/member-signup-controller-test/signup_201/response-fields.adoc[]
+
+==== 응답
+
+회원 가입 성공 시 응답
+
+include::{snippets}/member-signup-controller-test/signup_201/http-response.adoc[]
+
+===== 입력 유효성 체크 실패 시 응답
+
+요청 필드가 제약 조건을 지켜야 합니다.
+
+include::{snippets}/member-signup-controller-test/signup_400_invalid_input/http-response.adoc[]
+
+===== 이메일 미인증 시 응답
+
+이메일 인증을 받은 후에 회원 가입 요청을 진행해야 합니다. 요청 확인 후 회원 가입 유효 기간은 60분 입니다.
+
+include::{snippets}/member-signup-controller-test/signup_400_verified_email_not_found/http-response.adoc[]
+
+===== 이메일 중복 시 응답
+
+중복된 이메일로 가입할 수 없습니다.
+
+include::{snippets}/member-signup-controller-test/signup_409_email/http-response.adoc[]
+
+===== 닉네임 중복 시 응답
+
+중복된 닉네임으로 가입할 수 없습니다.
+
+include::{snippets}/member-signup-controller-test/signup_409_nickname/http-response.adoc[]

--- a/src/docs/asciidoc/member/confirmEmailVerification.adoc
+++ b/src/docs/asciidoc/member/confirmEmailVerification.adoc
@@ -1,0 +1,27 @@
+사용자가 이메일로 전송받은 인증 번호를 확인 요청합니다.
+
+=== 요청 필드
+
+include::{snippets}/email-verification-controller-test/confirm-email-verification_200/request-fields.adoc[]
+
+=== 요청
+
+include::{snippets}/email-verification-controller-test/confirm-email-verification_200/http-request.adoc[]
+
+=== 응답
+
+==== 인증번호 확인 성공 시 응답
+
+include::{snippets}/email-verification-controller-test/confirm-email-verification_200/http-response.adoc[]
+
+==== 인증 번호 확인 실패 시 응답
+
+include::{snippets}/email-verification-controller-test/confirm-email-verification_404/http-response.adoc[]
+
+==== 이메일 입력 유효성 체크 실패 시 응답
+
+include::{snippets}/email-verification-controller-test/confirm-email-verification_400_validation_email/http-response.adoc[]
+
+==== 코드 입력 유효성 체크 실패 시 응답
+
+include::{snippets}/email-verification-controller-test/confirm-email-verification_400_validation_code/http-response.adoc[]

--- a/src/docs/asciidoc/member/sendVerificationMail.adoc
+++ b/src/docs/asciidoc/member/sendVerificationMail.adoc
@@ -1,0 +1,28 @@
+회원 가입을 위한 이메일 인증 메일 전송을 요청합니다.
+
+=== 요청 필드
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_201/request-fields.adoc[]
+
+=== 요청
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-request.adoc[]
+
+=== 응답
+
+==== 인증 메일 전송 성공 시 응답
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-response.adoc[]
+
+==== 중복된 이메일로 요청 시 에러 응답
+
+이미 가입된 이메일로 가입할 수 없습니다.
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_409/http-response.adoc[]
+
+==== 메일 전송 실패 시 에러 응답
+
+존재하지 않는 메일로 메일을 전송할 수 없습니다.
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_400/http-response.adoc[]
+

--- a/src/docs/asciidoc/member/signup.adoc
+++ b/src/docs/asciidoc/member/signup.adoc
@@ -1,0 +1,43 @@
+회원 정보를 통해 회원 가입을 진행합니다.
+
+=== 요청 필드
+
+include::{snippets}/member-signup-controller-test/signup_201/request-fields.adoc[]
+
+=== 요청
+
+include::{snippets}/member-signup-controller-test/signup_201/http-request.adoc[]
+
+=== 응답 필드
+
+include::{snippets}/member-signup-controller-test/signup_201/response-fields.adoc[]
+
+=== 응답
+
+==== 회원 가입 성공 시 응답
+
+include::{snippets}/member-signup-controller-test/signup_201/http-response.adoc[]
+
+==== 입력 유효성 체크 실패 시 응답
+
+요청 필드가 제약 조건을 지켜야 합니다.
+
+include::{snippets}/member-signup-controller-test/signup_400_invalid_input/http-response.adoc[]
+
+==== 이메일 미인증 시 응답
+
+이메일 인증을 받은 후에 회원 가입 요청을 진행해야 합니다. 요청 확인 후 회원 가입 유효 기간은 60분 입니다.
+
+include::{snippets}/member-signup-controller-test/signup_400_verified_email_not_found/http-response.adoc[]
+
+==== 이메일 중복 시 응답
+
+중복된 이메일로 가입할 수 없습니다.
+
+include::{snippets}/member-signup-controller-test/signup_409_email/http-response.adoc[]
+
+==== 닉네임 중복 시 응답
+
+중복된 닉네임으로 가입할 수 없습니다.
+
+include::{snippets}/member-signup-controller-test/signup_409_nickname/http-response.adoc[]

--- a/src/docs/asciidoc/member/validateNickname.adoc
+++ b/src/docs/asciidoc/member/validateNickname.adoc
@@ -1,0 +1,27 @@
+이미 가입된 닉네임인지 검증을 요청합니다.
+
+=== 요청 쿼리 파라미터
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_200/query-parameters.adoc[]
+
+=== 요청
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_200/http-request.adoc[]
+
+=== 응답
+
+==== 사용 가능한 닉네임일 시 응답
+
+include::{snippets}/email-verification-controller-test/send-verification-mail_201/http-response.adoc[]
+
+==== 중복된 닉네임으로 요청 시 에러 응답
+
+이미 가입된 닉네임으로 가입할 수 없습니다.
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_409/http-response.adoc[]
+
+==== 유효성 조건을 통과하지 못한 닉네임으로 요청 시
+
+닉네임 constraints를 만족해야 합니다.
+
+include::{snippets}/nickname-validation-controller-test/validate-nickname_400_validation/http-response.adoc[]

--- a/src/main/java/me/coonect/coonect/common/security/configuration/SecurityConfiguration.java
+++ b/src/main/java/me/coonect/coonect/common/security/configuration/SecurityConfiguration.java
@@ -2,8 +2,10 @@ package me.coonect.coonect.common.security.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
@@ -33,6 +35,13 @@ public class SecurityConfiguration {
         .sessionManagement(AbstractHttpConfigurer::disable);
 
     return http.build();
+  }
+
+  @Profile("!prod")
+  @Bean
+  public WebSecurityCustomizer configureApiDocsEnable() {
+    return web -> web.ignoring()
+        .requestMatchers("/docs/**");
   }
 
 }

--- a/src/main/java/me/coonect/coonect/member/application/domain/exception/EmailDuplicationException.java
+++ b/src/main/java/me/coonect/coonect/member/application/domain/exception/EmailDuplicationException.java
@@ -1,10 +1,13 @@
 package me.coonect.coonect.member.application.domain.exception;
 
 import me.coonect.coonect.common.error.exception.DuplicationException;
+import me.coonect.coonect.common.error.exception.ErrorCode;
 
 public class EmailDuplicationException extends DuplicationException {
 
+  private static final ErrorCode errorCode = ErrorCode.EMAIL_DUPLICATE;
+
   public EmailDuplicationException(final String email) {
-    super(email);
+    super(email, errorCode);
   }
 }

--- a/src/main/java/me/coonect/coonect/member/application/domain/exception/NicknameDuplicationException.java
+++ b/src/main/java/me/coonect/coonect/member/application/domain/exception/NicknameDuplicationException.java
@@ -1,10 +1,13 @@
 package me.coonect.coonect.member.application.domain.exception;
 
 import me.coonect.coonect.common.error.exception.DuplicationException;
+import me.coonect.coonect.common.error.exception.ErrorCode;
 
 public class NicknameDuplicationException extends DuplicationException {
 
-  public NicknameDuplicationException(final String email) {
-    super(email);
+  private static final ErrorCode errorCode = ErrorCode.NICKNAME_DUPLICATE;
+
+  public NicknameDuplicationException(final String nickname) {
+    super(nickname, errorCode);
   }
 }

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/EmailVerificationConfirmCommand.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/EmailVerificationConfirmCommand.java
@@ -14,7 +14,6 @@ public class EmailVerificationConfirmCommand {
   String email;
 
   @EmailVerificationCode
-  @NotBlank
   String code;
 
   public EmailVerificationConfirmCommand(String email, String code) {

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/EmailVerificationConfirmCommand.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/EmailVerificationConfirmCommand.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import me.coonect.coonect.common.validation.Validator;
+import me.coonect.coonect.member.application.port.in.model.validation.EmailVerificationCode;
 
 @Getter
 public class EmailVerificationConfirmCommand {
@@ -12,6 +13,7 @@ public class EmailVerificationConfirmCommand {
   @NotBlank
   String email;
 
+  @EmailVerificationCode
   @NotBlank
   String code;
 

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommand.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommand.java
@@ -20,7 +20,6 @@ public class MemberSignupCommand {
   private final String email;
 
   @EmailVerificationCode
-  @NotBlank
   private final String emailVerificationCode;
 
   @Password

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommand.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommand.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import lombok.Getter;
 import me.coonect.coonect.common.validation.Validator;
 import me.coonect.coonect.member.application.domain.model.Member;
+import me.coonect.coonect.member.application.port.in.model.validation.EmailVerificationCode;
 import me.coonect.coonect.member.application.port.in.model.validation.Nickname;
 import me.coonect.coonect.member.application.port.in.model.validation.Password;
 
@@ -18,6 +19,8 @@ public class MemberSignupCommand {
   @NotBlank(message = "email은 공백일 수 없습니다.")
   private final String email;
 
+  @EmailVerificationCode
+  @NotBlank
   private final String emailVerificationCode;
 
   @Password

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/EmailVerificationCode.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/EmailVerificationCode.java
@@ -1,0 +1,23 @@
+package me.coonect.coonect.member.application.port.in.model.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import me.coonect.coonect.member.application.port.in.model.validation.validator.EmailVerificationCodeValidator;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = EmailVerificationCodeValidator.class)
+@Documented
+public @interface EmailVerificationCode {
+
+  String message() default "emailVerificationCode는 6자리 숫자로 이루어져야 합니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends String>[] payload() default {};
+}

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/EmailVerificationCodeValidator.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/EmailVerificationCodeValidator.java
@@ -2,6 +2,7 @@ package me.coonect.coonect.member.application.port.in.model.validation.validator
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
 import me.coonect.coonect.member.application.port.in.model.validation.EmailVerificationCode;
 
 public class EmailVerificationCodeValidator implements
@@ -11,6 +12,6 @@ public class EmailVerificationCodeValidator implements
 
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    return value.matches(REGEX);
+    return !Objects.isNull(value) && value.matches(REGEX);
   }
 }

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/EmailVerificationCodeValidator.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/EmailVerificationCodeValidator.java
@@ -1,0 +1,16 @@
+package me.coonect.coonect.member.application.port.in.model.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import me.coonect.coonect.member.application.port.in.model.validation.EmailVerificationCode;
+
+public class EmailVerificationCodeValidator implements
+    ConstraintValidator<EmailVerificationCode, String> {
+
+  private static final String REGEX = "^[0-9]{6}$";
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    return value.matches(REGEX);
+  }
+}

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/NicknameValidator.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/NicknameValidator.java
@@ -2,6 +2,7 @@ package me.coonect.coonect.member.application.port.in.model.validation.validator
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
 import me.coonect.coonect.member.application.port.in.model.validation.Nickname;
 
 public class NicknameValidator implements ConstraintValidator<Nickname, String> {
@@ -10,6 +11,6 @@ public class NicknameValidator implements ConstraintValidator<Nickname, String> 
 
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    return value.matches(REGEX);
+    return !Objects.isNull(value) && value.matches(REGEX);
   }
 }

--- a/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/PasswordValidator.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/in/model/validation/validator/PasswordValidator.java
@@ -2,6 +2,7 @@ package me.coonect.coonect.member.application.port.in.model.validation.validator
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
 import me.coonect.coonect.member.application.port.in.model.validation.Password;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
@@ -10,6 +11,6 @@ public class PasswordValidator implements ConstraintValidator<Password, String> 
 
   @Override
   public boolean isValid(String value, ConstraintValidatorContext context) {
-    return value.matches(REGEX);
+    return !Objects.isNull(value) && value.matches(REGEX);
   }
 }

--- a/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
+++ b/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
@@ -1,0 +1,51 @@
+package me.coonect.coonect.global;
+
+import static org.springframework.restdocs.snippet.Attributes.Attribute;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.coonect.coonect.common.security.configuration.SecurityConfiguration;
+import me.coonect.coonect.global.config.RestDocsConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@Disabled
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Import({RestDocsConfiguration.class, SecurityConfiguration.class})
+@ExtendWith(RestDocumentationExtension.class)
+public class RestDocsTestSupport {
+
+  @Autowired
+  protected RestDocumentationResultHandler restDocs;
+  @Autowired
+  protected MockMvc mockMvc;
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  protected static Attribute constraints(
+      final String value) {
+    return new Attribute("constraints", value);
+  }
+
+  @BeforeEach
+  void setUp(final WebApplicationContext context,
+      final RestDocumentationContextProvider provider) {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+        .alwaysDo(MockMvcResultHandlers.print())
+        .alwaysDo(restDocs)
+        .build();
+  }
+}

--- a/src/test/java/me/coonect/coonect/global/config/RestDocsConfiguration.java
+++ b/src/test/java/me/coonect/coonect/global/config/RestDocsConfiguration.java
@@ -1,0 +1,37 @@
+package me.coonect.coonect.global.config;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+
+@TestConfiguration
+public class RestDocsConfiguration {
+
+  @Bean
+  public RestDocumentationResultHandler restDocumentationResultHandler() {
+    return MockMvcRestDocumentation.document(
+        "{class-name}/{method-name}",
+        preprocessRequest(
+            modifyHeaders()
+                .remove("Content-Length")
+                .remove("Host"),
+            prettyPrint()),
+        preprocessResponse(
+            modifyHeaders()
+                .remove("Content-Length")
+                .remove("X-Content-Type-Options")
+                .remove("X-XSS-Protection")
+                .remove("Cache-Control")
+                .remove("Pragma")
+                .remove("Expires")
+                .remove("X-Frame-Options"),
+            prettyPrint())
+    );
+  }
+}

--- a/src/test/java/me/coonect/coonect/member/adapter/in/web/EmailVerificationControllerTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/web/EmailVerificationControllerTest.java
@@ -1,8 +1,12 @@
 package me.coonect.coonect.member.adapter.in.web;
 
 import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import me.coonect.coonect.common.error.exception.BusinessException;
 import me.coonect.coonect.common.error.exception.ErrorCode;
 import me.coonect.coonect.global.RestDocsTestSupport;
+import me.coonect.coonect.member.adapter.in.web.dto.request.EmailVerificationConfirmRequest;
 import me.coonect.coonect.member.adapter.in.web.dto.request.SendVerificationMailRequest;
 import me.coonect.coonect.member.application.domain.exception.EmailDuplicationException;
 import me.coonect.coonect.member.application.port.in.EmailVerificationUseCase;
@@ -36,7 +41,13 @@ class EmailVerificationControllerTest extends RestDocsTestSupport {
     mockMvc.perform(post("/member/email/verification/request")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
-        .andExpect(status().isCreated());
+        .andExpect(status().isCreated())
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("email")
+                    .type(STRING)
+                    .description("멤버 이메일")
+                    .attributes(constraints("이메일 형식")))));
 
     // then
   }
@@ -78,6 +89,81 @@ class EmailVerificationControllerTest extends RestDocsTestSupport {
         .andExpect(jsonPath("$.code").value(ErrorCode.MAIL_DELIVERY_ERROR.getCode()))
         .andExpect(jsonPath("$.message").value(ErrorCode.MAIL_DELIVERY_ERROR.getMessage()))
         .andExpect(jsonPath("$.reasons").isEmpty());
+
   }
 
+  @Test
+  public void confirmEmailVerification_200() throws Exception {
+    // given
+    given(emailVerificationUseCase.verifyEmail(any())).willReturn(true);
+
+    // when
+    // then
+    EmailVerificationConfirmRequest request = new EmailVerificationConfirmRequest(
+        "test@test.com", "123456");
+
+    mockMvc.perform(post("/member/email/verification/confirm")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("email")
+                    .type(STRING)
+                    .description("멤버 이메일")
+                    .attributes(constraints("이메일 형식")),
+                fieldWithPath("code")
+                    .type(STRING)
+                    .description("이메일 인증 코드")
+                    .attributes(constraints("6자리 숫자")))));
+
+  }
+
+  @Test
+  public void confirmEmailVerification_404() throws Exception {
+    // given
+    given(emailVerificationUseCase.verifyEmail(any())).willReturn(false);
+
+    // when
+    // then
+    EmailVerificationConfirmRequest request = new EmailVerificationConfirmRequest(
+        "test@test.com", "123456");
+
+    mockMvc.perform(post("/member/email/verification/confirm")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void confirmEmailVerification_400_validation_email() throws Exception {
+    // given
+    // when
+    EmailVerificationConfirmRequest request = new EmailVerificationConfirmRequest(
+        "test.com", "123456");
+
+    // then
+    mockMvc.perform(post("/member/email/verification/confirm")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_INPUT_VALUE.getMessage()));
+  }
+
+  @Test
+  public void confirmEmailVerification_400_validation_code() throws Exception {
+    // given
+    // when
+    EmailVerificationConfirmRequest request = new EmailVerificationConfirmRequest(
+        "test@test.com", "AAAAAA");
+
+    // then
+    mockMvc.perform(post("/member/email/verification/confirm")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_INPUT_VALUE.getMessage()));
+  }
 }

--- a/src/test/java/me/coonect/coonect/member/adapter/in/web/MemberSignupControllerTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/web/MemberSignupControllerTest.java
@@ -1,49 +1,191 @@
 package me.coonect.coonect.member.adapter.in.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.Duration;
 import java.time.LocalDate;
+import me.coonect.coonect.common.error.exception.ErrorCode;
+import me.coonect.coonect.common.error.exception.NotFoundException;
+import me.coonect.coonect.global.RestDocsTestSupport;
 import me.coonect.coonect.member.adapter.in.web.dto.request.MemberSignupRequest;
-import me.coonect.coonect.member.adapter.in.web.dto.response.MemberResponse;
-import me.coonect.coonect.member.application.port.out.persistence.VerifiedEmailRepository;
-import me.coonect.coonect.mock.TestContainer;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
+import me.coonect.coonect.member.application.domain.exception.EmailDuplicationException;
+import me.coonect.coonect.member.application.domain.exception.NicknameDuplicationException;
+import me.coonect.coonect.member.application.domain.model.Member;
+import me.coonect.coonect.member.application.port.in.MemberSignupUseCase;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class MemberSignupControllerTest {
+@WebMvcTest(MemberSignupController.class)
+class MemberSignupControllerTest extends RestDocsTestSupport {
+
+  @MockBean
+  private MemberSignupUseCase memberSignupUseCase;
 
   @Test
-  public void 회원_가입에_성공하면_201_응답을_내린다() throws Exception {
+  public void signup_201() throws Exception {
     // given
-    TestContainer testContainer = TestContainer.builder().build();
 
-    MemberSignupController memberSignupController = testContainer.memberSignupController;
-    VerifiedEmailRepository verifiedEmailRepository = testContainer.verifiedEmailRepository;
-
-    verifiedEmailRepository.save("duk9741@gmail.com", "123456", Duration.ZERO);
-
-    MemberSignupRequest request = new MemberSignupRequest("duk9741@gmail.com",
-        "123456",
-        "!@#qwe123",
-        "닉네임",
+    Member member = Member.withEncodedPassword(1L,
+        "test@test.com",
+        "encoded-password",
+        "nickname",
         LocalDate.of(1995, 1, 10));
 
-    // when
-    ResponseEntity<MemberResponse> result = memberSignupController.signup(request);
+    given(memberSignupUseCase.signup(any())).willReturn(member);
 
+    // when
     // then
-    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(201));
-    assertThat(result.getBody()).isNotNull();
-    assertThat(result.getBody().getId()).isEqualTo(1L);
-    assertThat(result.getBody().getEmail()).isEqualTo("duk9741@gmail.com");
-    assertThat(result.getBody().getNickname()).isEqualTo("닉네임");
-    // then
+    MemberSignupRequest request = new MemberSignupRequest(
+        "test@test.com",
+        "123456",
+        "raw@password1",
+        "nickname",
+        LocalDate.of(1995, 1, 10));
+
+    mockMvc.perform(post("/member")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.email").value("test@test.com"))
+        .andExpect(jsonPath("$.nickname").value("nickname"))
+        .andDo(restDocs.document(
+            requestFields(
+                fieldWithPath("email")
+                    .type(STRING)
+                    .description("멤버 이메일")
+                    .attributes(constraints("이메일 형식")),
+                fieldWithPath("nickname")
+                    .type(STRING)
+                    .description("멤버 닉네임")
+                    .attributes(constraints("2자 이상 10자 이하 형식")),
+                fieldWithPath("password")
+                    .type(STRING)
+                    .description("멤버 패스워드")
+                    .attributes(constraints("8자 이상 20자 이하 최소 1글자 이상의 영어, 숫자, 특수문자 포함")),
+                fieldWithPath("emailVerificationCode")
+                    .type(STRING)
+                    .description("이메일 인증 코드")
+                    .attributes(constraints("6자리 숫자")),
+                fieldWithPath("birthday")
+                    .type(STRING)
+                    .description("멤버 생년월일")
+                    .attributes(constraints("YYYY-MM-DD"))
+            ),
+            responseFields(
+                fieldWithPath("id")
+                    .type(NUMBER)
+                    .description("멤버 고유 번호"),
+                fieldWithPath("email")
+                    .type(STRING)
+                    .description("멤버 이메일"),
+                fieldWithPath("nickname")
+                    .type(STRING)
+                    .description("멤버 닉네임")
+            )));
 
   }
 
+  @Test
+  public void signup_400_invalid_input() throws Exception {
+    // given
+    MemberSignupRequest request = new MemberSignupRequest(
+        "test.com",
+        "12345A",
+        "!password2",
+        "가가가",
+        LocalDate.of(1995, 1, 10));
+
+    // when
+    // then
+
+    mockMvc.perform(post("/member")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_INPUT_VALUE.getMessage()));
+  }
+
+  @Test
+  public void signup_409_nickname() throws Exception {
+    // given
+    MemberSignupRequest request = new MemberSignupRequest(
+        "test@test.com",
+        "123456",
+        "raw@password1",
+        "nickname",
+        LocalDate.of(1995, 1, 10));
+
+    willThrow(new NicknameDuplicationException("nickname"))
+        .given(memberSignupUseCase).signup(any());
+
+    // when
+    // then
+    mockMvc.perform(post("/member")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(ErrorCode.NICKNAME_DUPLICATE.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.NICKNAME_DUPLICATE.getMessage()))
+        .andExpect(jsonPath("$.reasons[0]").value("nickname"));
+  }
+
+  @Test
+  public void signup_409_email() throws Exception {
+    // given
+    MemberSignupRequest request = new MemberSignupRequest(
+        "test@test.com",
+        "123456",
+        "raw@password1",
+        "nickname",
+        LocalDate.of(1995, 1, 10));
+
+    willThrow(new EmailDuplicationException("test@test.com"))
+        .given(memberSignupUseCase).signup(any());
+
+    // when
+    // then
+    mockMvc.perform(post("/member")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value(ErrorCode.EMAIL_DUPLICATE.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.EMAIL_DUPLICATE.getMessage()))
+        .andExpect(jsonPath("$.reasons[0]").value("test@test.com"));
+  }
+
+  @Test
+  public void signup_400_verified_email_not_found() throws Exception {
+    // given
+    MemberSignupRequest request = new MemberSignupRequest(
+        "test@test.com",
+        "123456",
+        "raw@password1",
+        "nickname",
+        LocalDate.of(1995, 1, 10));
+
+    willThrow(new NotFoundException(ErrorCode.VERIFIED_EMAIL_NOT_FOUND))
+        .given(memberSignupUseCase).signup(any());
+
+    // when
+    // then
+    mockMvc.perform(post("/member")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value(ErrorCode.VERIFIED_EMAIL_NOT_FOUND.getCode()))
+        .andExpect(jsonPath("$.message").value(ErrorCode.VERIFIED_EMAIL_NOT_FOUND.getMessage()));
+  }
 }

--- a/src/test/java/me/coonect/coonect/member/adapter/in/web/NicknameValidationControllerTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/web/NicknameValidationControllerTest.java
@@ -32,6 +32,7 @@ class NicknameValidationControllerTest extends RestDocsTestSupport {
         .andDo(restDocs.document(
             queryParameters(
                 parameterWithName("nickname").description("유저 닉네임")
+                    .attributes(constraints("8자 이상 20자 이하 최소 1글자 이상의 영어, 숫자, 특수문자 포함"))
             )
         ));
 

--- a/src/test/java/me/coonect/coonect/member/adapter/in/web/NicknameValidationControllerTest.java
+++ b/src/test/java/me/coonect/coonect/member/adapter/in/web/NicknameValidationControllerTest.java
@@ -1,68 +1,67 @@
 package me.coonect.coonect.member.adapter.in.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.LocalDate;
-import me.coonect.coonect.member.adapter.in.web.NicknameValidationController;
-import me.coonect.coonect.member.application.domain.model.Member;
-import me.coonect.coonect.member.application.port.out.persistence.MemberRepository;
-import me.coonect.coonect.mock.TestContainer;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
+import me.coonect.coonect.global.RestDocsTestSupport;
+import me.coonect.coonect.member.application.port.in.NicknameValidationUseCase;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class NicknameValidationControllerTest {
+@WebMvcTest(NicknameValidationController.class)
+class NicknameValidationControllerTest extends RestDocsTestSupport {
 
-  private NicknameValidationController nicknameValidationController;
-  private MemberRepository memberRepository;
+  @MockBean
+  private NicknameValidationUseCase nicknameValidationUseCase;
 
   @Test
-  public void 닉네임이_겹치면_409_응답을_내린다() throws Exception {
+  public void validateNickname_200() throws Exception {
     // given
-    TestContainer testContainer = TestContainer.builder().build();
-
-    nicknameValidationController = testContainer.nicknameValidationController;
-    memberRepository = testContainer.memberRepository;
-
-    memberRepository.save(Member.withoutId("duk9741@gmail.com",
-        "@12cdefghijkl",
-        "dukcode",
-        LocalDate.of(1995, 1, 10)));
-
-    String nickname = "dukcode";
+    given(nicknameValidationUseCase.isNicknameDuplicated(any()))
+        .willReturn(false);
 
     // when
-    ResponseEntity<Void> result = nicknameValidationController.validNickname(nickname);
+    mockMvc.perform(get("/member/nickname/valid").queryParam("nickname", "dukcode"))
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            queryParameters(
+                parameterWithName("nickname").description("유저 닉네임")
+            )
+        ));
 
     // then
-    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(409));
-    assertThat(result.getBody()).isNull();
+    verify(nicknameValidationUseCase).isNicknameDuplicated(any());
   }
 
   @Test
-  public void 닉네임이_겹치지_않으면_200_응답을_내린다() throws Exception {
+  public void validateNickname_400_validation() throws Exception {
     // given
-    TestContainer testContainer = TestContainer.builder().build();
+    // when
+    // then
+    mockMvc.perform(get("/member/nickname/valid").queryParam("nickname", "ㄱ"))
+        .andExpect(status().isBadRequest());
 
-    nicknameValidationController = testContainer.nicknameValidationController;
-    memberRepository = testContainer.memberRepository;
+  }
 
-    memberRepository.save(Member.withoutId("duk9741@gmail.com",
-        "@12cdefghijkl",
-        "dukcode",
-        LocalDate.of(1995, 1, 10)));
-
-    String nickname = "newname";
+  @Test
+  public void validateNickname_409() throws Exception {
+    // given
+    given(nicknameValidationUseCase.isNicknameDuplicated(any()))
+        .willReturn(true);
 
     // when
-    ResponseEntity<Void> result = nicknameValidationController.validNickname(nickname);
+    mockMvc.perform(get("/member/nickname/valid").queryParam("nickname", "dukcode"))
+        .andExpect(status().isConflict());
 
     // then
-    assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
-    assertThat(result.getBody()).isNull();
+    verify(nicknameValidationUseCase).isNicknameDuplicated(any());
   }
+
 
 }

--- a/src/test/java/me/coonect/coonect/member/application/port/in/model/EmailVerificationConfirmCommandTest.java
+++ b/src/test/java/me/coonect/coonect/member/application/port/in/model/EmailVerificationConfirmCommandTest.java
@@ -78,4 +78,26 @@ class EmailVerificationConfirmCommandTest {
     ).isInstanceOf(ConstraintViolationException.class)
         .hasMessageContaining("code");
   }
+
+  @Test
+  public void code_는_6자리_숫자여야_한다() throws Exception {
+    // given
+    // when
+    // then
+    assertThatThrownBy(() ->
+        new EmailVerificationConfirmCommand("duk9741@gmail.com", "123A")
+    ).isInstanceOf(ConstraintViolationException.class)
+        .hasMessageContaining("code");
+  }
+
+  @Test
+  public void code_는_6자리를_넘을_수_없다() throws Exception {
+    // given
+    // when
+    // then
+    assertThatThrownBy(() ->
+        new EmailVerificationConfirmCommand("duk9741@gmail.com", "1234567")
+    ).isInstanceOf(ConstraintViolationException.class)
+        .hasMessageContaining("code");
+  }
 }

--- a/src/test/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommandTest.java
+++ b/src/test/java/me/coonect/coonect/member/application/port/in/model/MemberSignupCommandTest.java
@@ -241,6 +241,20 @@ class MemberSignupCommandTest {
   }
 
   @Test
+  public void emailVerificationCode_에_유효성_체크가_적용된다() throws Exception {
+    // given
+    // when
+    // then
+    assertThatThrownBy(() ->
+        new MemberSignupCommand("duk9741@gmail.com",
+            "123A", "@12cdefghijkl",
+            "dukcode",
+            LocalDate.of(1995, 1, 10))
+    ).isInstanceOf(ConstraintViolationException.class)
+        .hasMessageContaining("emailVerificationCode");
+  }
+
+  @Test
   public void MemberSignupCommand_를_Member_로_변환할_수_있다() throws Exception {
     // given
     MemberSignupCommand memberSignupCommand
@@ -258,6 +272,5 @@ class MemberSignupCommandTest {
     assertThat(member.getNickname()).isEqualTo("dukcode");
     assertThat(member.getEncodedPassword()).isNotEqualTo("@12cdefghijkl");
     assertThat(member.getBirthday()).isEqualTo(LocalDate.of(1995, 1, 10));
-
   }
 }

--- a/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,0 +1,11 @@
+|===
+|파라미터명|필수여부|제약조건|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}O{{/optional}}{{#optional}}X{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,10 @@
+|===
+|필드명|타입|필수여부|제약조건|설명
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}O{{/optional}}{{#optional}}X{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+|===


### PR DESCRIPTION
## 작업 내용

Spring REST Docs를 구성했습니다.

## 핵심 변경 사항

- 기존 컨트롤러 Test를 WebMvcTest로 변경
- 커스텀 스니펫 생성
- test 태스크 실행 시 기존 html 삭제 후 html 문서 저장
- bootJar 태스크 실행 시 기존 html 삭제 후 html 문서 저장

## 테스트 결과

<!-- 테스트 결과를 첨부해 주세요 -->
- 테스트 결과 79/79 성공

<img width="337" alt="image" src="https://github.com/coonect-projects/coonect-api/assets/59705184/672af52c-9b01-4235-8209-5b866a392bbd">

- 클래스 커버리지 100%, 메서드 커버리지 87%, 라인 커버리지 85% 달성

<img width="351" alt="image" src="https://github.com/coonect-projects/coonect-api/assets/59705184/e60bc25a-1f68-4fdc-be25-042b49865843">

- API 문서 저장 확인

<img width="212" alt="image" src="https://github.com/coonect-projects/coonect-api/assets/59705184/7ae5366d-ff2b-4e8d-8d64-035368435432">


## 닫힌 이슈

close #10

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
