### PR TITLE
JWT 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'com.auth0:java-jwt:4.4.0'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -21,3 +21,6 @@ include::{docdir}/member/validateNickname.adoc[]
 
 include::{docdir}/member/signup.adoc[]
 
+== 로그인
+
+include::{docdir}/member/login.adoc[]

--- a/src/docs/asciidoc/member/login.adoc
+++ b/src/docs/asciidoc/member/login.adoc
@@ -1,0 +1,23 @@
+사용자가 로그인을 요청합니다.
+
+=== 요청 필드
+
+include::{snippets}/auth-api-test/login_200/request-fields.adoc[]
+
+=== 요청
+
+include::{snippets}/auth-api-test/login_200/http-request.adoc[]
+
+=== 응답 필드
+
+include::{snippets}/auth-api-test/login_200/response-fields.adoc[]
+
+=== 응답
+
+==== 로그인 성공 시 응답
+
+include::{snippets}/auth-api-test/login_200/http-response.adoc[]
+
+==== 로그인 실패 시 응답
+
+include::{snippets}/auth-api-test/login_401/http-response.adoc[]

--- a/src/main/java/me/coonect/coonect/common/error/exception/ErrorCode.java
+++ b/src/main/java/me/coonect/coonect/common/error/exception/ErrorCode.java
@@ -4,6 +4,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_CONFLICT;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import lombok.Getter;
 
@@ -17,6 +18,8 @@ public enum ErrorCode {
   INVALID_TYPE_VALUE(SC_BAD_REQUEST, "C-001", "Invalid Type Value"),
   INVALID_INPUT_VALUE(SC_BAD_REQUEST, "C-002", "Invalid Input Value"),
 
+  // Authentication
+  INVALID_USERNAME_OR_PASSWORD(SC_UNAUTHORIZED, "A-001", "Invalid Username or Password"),
 
   // Business
   DUPLICATE(SC_CONFLICT, "B-001", "Duplicated Value"),

--- a/src/main/java/me/coonect/coonect/common/jwt/adapter/out/persistence/RefreshTokenRedisRepository.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/adapter/out/persistence/RefreshTokenRedisRepository.java
@@ -1,0 +1,29 @@
+package me.coonect.coonect.common.jwt.adapter.out.persistence;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.common.jwt.application.port.out.persistence.RefreshTokenRepository;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class RefreshTokenRedisRepository implements RefreshTokenRepository {
+
+  private static final String KEY_PREFIX = "refreshToken:";
+  private final StringRedisTemplate redisTemplate;
+
+  @Override
+  public void update(String username, String refreshToken) {
+    ValueOperations<String, String> ops = redisTemplate.opsForValue();
+    ops.set(KEY_PREFIX + username, refreshToken);
+  }
+
+  @Override
+  public Optional<String> find(String username) {
+    ValueOperations<String, String> ops = redisTemplate.opsForValue();
+    return Optional.ofNullable(ops.get(KEY_PREFIX + username));
+  }
+
+}

--- a/src/main/java/me/coonect/coonect/common/jwt/application/port/out/persistence/RefreshTokenRepository.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/port/out/persistence/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package me.coonect.coonect.common.jwt.application.port.out.persistence;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+
+  /**
+   * refresh token을 저장한다. username에 refresh token이 이미 존재하면 값을 업데이트 한다.
+   */
+  void update(String username, String refreshToken);
+
+  Optional<String> find(String username);
+}

--- a/src/main/java/me/coonect/coonect/common/jwt/application/service/JwtProperties.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/service/JwtProperties.java
@@ -1,0 +1,26 @@
+package me.coonect.coonect.common.jwt.application.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Component
+public class JwtProperties {
+
+  @Value("${coonect.jwt.properties.secret}")
+  private String secret;
+  @Value("${coonect.jwt.properties.access-token-expiration-seconds}")
+  private Long accessTokenExpirationSeconds;
+  @Value("${coonect.jwt.properties.refresh-token-expiration-seconds}")
+  private Long refreshTokenExpirationSeconds;
+  @Value("${coonect.jwt.properties.token-type}")
+  private String tokenType;
+
+}

--- a/src/main/java/me/coonect/coonect/common/jwt/application/service/JwtService.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/service/JwtService.java
@@ -1,0 +1,55 @@
+package me.coonect.coonect.common.jwt.application.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.common.jwt.application.port.out.persistence.RefreshTokenRepository;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class JwtService {
+
+  private static final String ACCESS_TOKEN_SUBJECT = "access-token";
+  private static final String REFRESH_TOKEN_SUBJECT = "refresh-token";
+  private static final String USERNAME_CLAIM = "email";
+  private static final String ROLES_CLAIM = "roles";
+
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtProperties jwtProperties;
+
+  public TokenResponse generateTokens(String username, List<String> roles) {
+    String assessToken = generateAccessToken(username, roles);
+    String refreshToken = generateRefreshToken(username, roles);
+
+    return new TokenResponse(jwtProperties.getTokenType(),
+        assessToken,
+        jwtProperties.getAccessTokenExpirationSeconds(),
+        refreshToken,
+        jwtProperties.getRefreshTokenExpirationSeconds());
+  }
+
+  private String generateAccessToken(String username, List<String> roles) {
+    return generateTokenWithSubject(ACCESS_TOKEN_SUBJECT, username, roles);
+  }
+
+  private String generateRefreshToken(String username, List<String> roles) {
+    String refreshToken = generateTokenWithSubject(REFRESH_TOKEN_SUBJECT, username, roles);
+    refreshTokenRepository.update(username, refreshToken);
+    return refreshToken;
+  }
+
+  private String generateTokenWithSubject(String subject, String username, List<String> roles) {
+    Algorithm algorithm = Algorithm.HMAC256(jwtProperties.getSecret());
+    return JWT.create().withSubject(subject)
+        .withIssuedAt(new Date(System.currentTimeMillis()))
+        .withExpiresAt(new Date(System.currentTimeMillis()
+            + jwtProperties.getAccessTokenExpirationSeconds() * 1000L))
+        .withClaim(USERNAME_CLAIM, username)
+        .withClaim(ROLES_CLAIM, roles)
+        .sign(algorithm);
+  }
+
+}

--- a/src/main/java/me/coonect/coonect/common/jwt/application/service/TokenResponse.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/service/TokenResponse.java
@@ -1,0 +1,16 @@
+package me.coonect.coonect.common.jwt.application.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+
+  private String tokenType;
+  private String accessToken;
+  private Long accessTokenExpiresIn;
+  private String refreshToken;
+  private Long refreshTokenExpiresIn;
+
+}

--- a/src/main/java/me/coonect/coonect/common/security/configuration/SecurityConfiguration.java
+++ b/src/main/java/me/coonect/coonect/common/security/configuration/SecurityConfiguration.java
@@ -1,17 +1,33 @@
 package me.coonect.coonect.common.security.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.common.security.login.filter.JsonLoginProcessingFilter;
+import me.coonect.coonect.common.security.login.handler.LoginFailureHandler;
+import me.coonect.coonect.common.security.login.service.UserDetailsServiceImpl;
+import me.coonect.coonect.member.application.port.out.persistence.MemberRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
+@RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class SecurityConfiguration {
@@ -21,8 +37,12 @@ public class SecurityConfiguration {
       new AntPathRequestMatcher("/member", "POST"),
       new AntPathRequestMatcher("/member/nickname/valid", "GET"),
       new AntPathRequestMatcher("/member/email/verification/request", "POST"),
-      new AntPathRequestMatcher("/member/email/verification/confirm", "POST")
+      new AntPathRequestMatcher("/member/email/verification/confirm", "POST"),
+      new AntPathRequestMatcher("/login", "POST")
   };
+
+  private final ObjectMapper objectMapper;
+  private final MemberRepository memberRepository;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -34,7 +54,46 @@ public class SecurityConfiguration {
         .requestCache(RequestCacheConfigurer::disable)
         .sessionManagement(AbstractHttpConfigurer::disable);
 
+    http.addFilterAt(loginProcessingFilter(),
+        UsernamePasswordAuthenticationFilter.class);
+
     return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+  @Bean
+  public UserDetailsService userDetailsService() {
+    return new UserDetailsServiceImpl(memberRepository);
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager() {
+    DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+    provider.setPasswordEncoder(passwordEncoder());
+    provider.setUserDetailsService(userDetailsService());
+    return new ProviderManager(provider);
+  }
+
+  @Bean
+  public AbstractAuthenticationProcessingFilter loginProcessingFilter() throws Exception {
+    JsonLoginProcessingFilter jsonLoginProcessingFilter =
+        new JsonLoginProcessingFilter(objectMapper);
+
+    jsonLoginProcessingFilter.setAuthenticationManager(
+        authenticationManager());
+
+    jsonLoginProcessingFilter.setAuthenticationFailureHandler(loginFailureHandler());
+
+    return jsonLoginProcessingFilter;
+  }
+
+  @Bean
+  public AuthenticationFailureHandler loginFailureHandler() {
+    return new LoginFailureHandler(objectMapper);
   }
 
   @Profile("!prod")

--- a/src/main/java/me/coonect/coonect/common/security/login/filter/JsonLoginProcessingFilter.java
+++ b/src/main/java/me/coonect/coonect/common/security/login/filter/JsonLoginProcessingFilter.java
@@ -1,0 +1,85 @@
+package me.coonect.coonect.common.security.login.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.Assert;
+
+public class JsonLoginProcessingFilter extends AbstractAuthenticationProcessingFilter {
+
+
+  public static final String DEFAULT_USERNAME_KEY = "email";
+  public static final String DEFAULT_PASSWORD_KEY = "password";
+
+  private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER =
+      new AntPathRequestMatcher("/login", "POST");
+  private final ObjectMapper objectMapper;
+  private String usernameParameter = DEFAULT_USERNAME_KEY;
+  private String passwordParameter = DEFAULT_PASSWORD_KEY;
+  private boolean postOnly = true;
+
+  public JsonLoginProcessingFilter(ObjectMapper objectMapper) {
+    super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request,
+      HttpServletResponse response) throws AuthenticationException, IOException {
+    if (this.postOnly && !request.getMethod().equals("POST")) {
+      throw new AuthenticationServiceException(
+          "Authentication method not supported: " + request.getMethod());
+    }
+
+    if (!request.getContentType().equals(MediaType.APPLICATION_JSON_VALUE)) {
+      throw new AuthenticationServiceException(
+          "Authentication content-type not supported: " + request.getContentType());
+    }
+
+    ServletInputStream inputStream = request.getInputStream();
+    Map<String, String> usernamePasswordMap = objectMapper.readValue(inputStream, Map.class);
+
+    String username = obtainParameter(usernameParameter, usernamePasswordMap);
+    String password = obtainParameter(passwordParameter, usernamePasswordMap);
+
+    UsernamePasswordAuthenticationToken authRequest =
+        UsernamePasswordAuthenticationToken.unauthenticated(username, password);
+
+    return getAuthenticationManager().authenticate(authRequest);
+  }
+
+  public void setUsernameParameter(String usernameParameter) {
+    Assert.hasText(usernameParameter, "Username parameter must not be empty or null");
+    this.usernameParameter = usernameParameter;
+  }
+
+  public void setPasswordParameter(String passwordParameter) {
+    Assert.hasText(passwordParameter, "Password parameter must not be empty or null");
+    this.passwordParameter = passwordParameter;
+  }
+
+  public void setPostOnly(boolean postOnly) {
+    this.postOnly = postOnly;
+  }
+
+  private String obtainParameter(String parameter, Map<String, String> usernamePasswordMap) {
+    String value = usernamePasswordMap.get(parameter);
+    if (Objects.isNull(value)) {
+      return "";
+    }
+
+    return value;
+  }
+
+}

--- a/src/main/java/me/coonect/coonect/common/security/login/handler/ErrorResponseAuthenticationFailureHandler.java
+++ b/src/main/java/me/coonect/coonect/common/security/login/handler/ErrorResponseAuthenticationFailureHandler.java
@@ -13,7 +13,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
 @RequiredArgsConstructor
-public class LoginFailureHandler implements AuthenticationFailureHandler {
+public class ErrorResponseAuthenticationFailureHandler implements AuthenticationFailureHandler {
 
   private final ObjectMapper objectMapper;
 

--- a/src/main/java/me/coonect/coonect/common/security/login/handler/JwtAuthenticationSuccessHandler.java
+++ b/src/main/java/me/coonect/coonect/common/security/login/handler/JwtAuthenticationSuccessHandler.java
@@ -1,0 +1,42 @@
+package me.coonect.coonect.common.security.login.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.common.jwt.application.service.JwtService;
+import me.coonect.coonect.common.jwt.application.service.TokenResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final JwtService jwtService;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException {
+    UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+    String username = userDetails.getUsername();
+    List<String> roles = userDetails.getAuthorities().stream()
+        .map(GrantedAuthority::toString)
+        .toList();
+
+    TokenResponse tokenResponse = jwtService.generateTokens(username, roles);
+    String body = objectMapper.writeValueAsString(tokenResponse);
+
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.getWriter().write(body);
+    response.setStatus(HttpStatus.OK.value());
+  }
+}

--- a/src/main/java/me/coonect/coonect/common/security/login/handler/LoginFailureHandler.java
+++ b/src/main/java/me/coonect/coonect/common/security/login/handler/LoginFailureHandler.java
@@ -1,0 +1,34 @@
+package me.coonect.coonect.common.security.login.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.common.error.ErrorResponse;
+import me.coonect.coonect.common.error.exception.ErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+@RequiredArgsConstructor
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException {
+
+    ErrorCode code = ErrorCode.INVALID_USERNAME_OR_PASSWORD;
+    ErrorResponse errorResponse = ErrorResponse.of(code);
+
+    String body = objectMapper.writeValueAsString(errorResponse);
+    response.setStatus(code.getStatus());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.getWriter().write(body);
+  }
+
+}

--- a/src/main/java/me/coonect/coonect/common/security/login/service/UserDetailsServiceImpl.java
+++ b/src/main/java/me/coonect/coonect/common/security/login/service/UserDetailsServiceImpl.java
@@ -1,0 +1,28 @@
+package me.coonect.coonect.common.security.login.service;
+
+import lombok.RequiredArgsConstructor;
+import me.coonect.coonect.member.application.domain.model.Member;
+import me.coonect.coonect.member.application.port.out.persistence.MemberRepository;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    Member member = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자 입니다."));
+    return User.builder()
+        .username(member.getEmail())
+        .password(member.getEncodedPassword())
+        .roles("MEMBER")
+        .build();
+  }
+}

--- a/src/main/java/me/coonect/coonect/member/adapter/out/persistence/MemberJpaRepository.java
+++ b/src/main/java/me/coonect/coonect/member/adapter/out/persistence/MemberJpaRepository.java
@@ -1,5 +1,6 @@
 package me.coonect.coonect.member.adapter.out.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Long> {
@@ -7,4 +8,6 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Long
   boolean existsByNickname(String nickname);
 
   boolean existsByEmail(String email);
+
+  Optional<MemberJpaEntity> findByEmail(String email);
 }

--- a/src/main/java/me/coonect/coonect/member/adapter/out/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/me/coonect/coonect/member/adapter/out/persistence/MemberRepositoryImpl.java
@@ -1,5 +1,6 @@
 package me.coonect.coonect.member.adapter.out.persistence;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import me.coonect.coonect.member.application.domain.model.Member;
 import me.coonect.coonect.member.application.port.out.persistence.MemberRepository;
@@ -24,6 +25,11 @@ public class MemberRepositoryImpl implements MemberRepository {
   @Override
   public boolean existsByEmail(String email) {
     return memberJpaRepository.existsByEmail(email);
+  }
+
+  @Override
+  public Optional<Member> findByEmail(String email) {
+    return memberJpaRepository.findByEmail(email).map(MemberJpaEntity::toMember);
   }
 
 

--- a/src/main/java/me/coonect/coonect/member/application/port/out/persistence/MemberRepository.java
+++ b/src/main/java/me/coonect/coonect/member/application/port/out/persistence/MemberRepository.java
@@ -1,5 +1,6 @@
 package me.coonect.coonect.member.application.port.out.persistence;
 
+import java.util.Optional;
 import me.coonect.coonect.member.application.domain.model.Member;
 
 public interface MemberRepository {
@@ -10,4 +11,5 @@ public interface MemberRepository {
 
   boolean existsByEmail(String email);
 
+  Optional<Member> findByEmail(String email);
 }

--- a/src/test/java/me/coonect/coonect/common/jwt/application/service/JwtServiceTest.java
+++ b/src/test/java/me/coonect/coonect/common/jwt/application/service/JwtServiceTest.java
@@ -1,0 +1,56 @@
+package me.coonect.coonect.common.jwt.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import me.coonect.coonect.common.jwt.application.port.out.persistence.RefreshTokenRepository;
+import me.coonect.coonect.mock.FakeRefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JwtServiceTest {
+
+  private JwtService jwtService;
+  private RefreshTokenRepository refreshTokenRepository;
+
+  @BeforeEach
+  public void init() {
+    refreshTokenRepository = new FakeRefreshTokenRepository();
+    jwtService = new JwtService(refreshTokenRepository, new JwtProperties(
+        "secret-secret",
+        100L,
+        200L,
+        "Bearer"
+    ));
+  }
+
+  @Test
+  public void 토큰을_발급할_수_있다() throws Exception {
+    // given
+    // when
+    TokenResponse tokenResponse = jwtService.generateTokens("duk9741@gmail.com", List.of("MEMBER"));
+
+    // then
+    assertThat(tokenResponse.getTokenType()).isEqualTo("Bearer");
+    assertThat(tokenResponse.getAccessToken()).isNotBlank();
+    assertThat(tokenResponse.getAccessTokenExpiresIn()).isEqualTo(100L);
+    assertThat(tokenResponse.getRefreshToken()).isNotBlank();
+    assertThat(tokenResponse.getRefreshTokenExpiresIn()).isEqualTo(200L);
+
+  }
+
+  @Test
+  public void 리프레시_토큰을_발급하면_저장된다() throws Exception {
+    // given
+    // when
+    TokenResponse tokenResponse = jwtService.generateTokens("duk9741@gmail.com", List.of("MEMBER"));
+
+    // then
+    assertThat(refreshTokenRepository.find("duk9741@gmail.com")).isNotEmpty();
+
+  }
+
+}

--- a/src/test/java/me/coonect/coonect/common/security/login/filter/JsonLoginProcessingFilterTest.java
+++ b/src/test/java/me/coonect/coonect/common/security/login/filter/JsonLoginProcessingFilterTest.java
@@ -1,0 +1,123 @@
+package me.coonect.coonect.common.security.login.filter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JsonLoginProcessingFilterTest {
+
+  private JsonLoginProcessingFilter jsonLoginProcessingFilter;
+  private AuthenticationManager authenticationManager;
+  private ObjectMapper objectMapper;
+
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  @BeforeEach
+  public void init() {
+    objectMapper = new ObjectMapper();
+    jsonLoginProcessingFilter = new JsonLoginProcessingFilter(objectMapper);
+
+    authenticationManager = mock(AuthenticationManager.class);
+
+    jsonLoginProcessingFilter.setAuthenticationManager(authenticationManager);
+
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  public void POST_메서드가_아니면_예외를_발생시킨다() throws Exception {
+    // given
+    request.setMethod("GET");
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+    // when
+    // then
+    Assertions.assertThatThrownBy(() -> {
+      jsonLoginProcessingFilter.attemptAuthentication(request, response);
+    }).isInstanceOf(AuthenticationServiceException.class);
+  }
+
+  @Test
+  public void Content_Type_이_json_이_아니면_예외를_발생시킨다() throws Exception {
+    // given
+    request.setMethod("POST");
+    request.setContentType(MediaType.APPLICATION_PDF_VALUE);
+
+    // when
+    // then
+    Assertions.assertThatThrownBy(() -> {
+      jsonLoginProcessingFilter.attemptAuthentication(request, response);
+    }).isInstanceOf(AuthenticationServiceException.class);
+  }
+
+  @Test
+  public void email_과_password_가_둘다_존재하면_인증을_시도한다() throws Exception {
+    // given
+    Map<String, String> body = new HashMap<>();
+    body.put("email", "duk9741@gmail.com");
+    body.put("password", "123qwe456rty");
+
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setMethod("POST");
+    request.setContent(objectMapper.writeValueAsBytes(body));
+
+    // when
+    jsonLoginProcessingFilter.attemptAuthentication(request, response);
+
+    // then
+    verify(authenticationManager).authenticate(any(Authentication.class));
+  }
+
+  @Test
+  public void email_이_없어도_인증을_시도한다() throws Exception {
+    // given
+    Map<String, String> body = new HashMap<>();
+    body.put("password", "123qwe456rty");
+
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setMethod("POST");
+    request.setContent(objectMapper.writeValueAsBytes(body));
+
+    // when
+    jsonLoginProcessingFilter.attemptAuthentication(request, response);
+
+    // then
+    verify(authenticationManager).authenticate(any(Authentication.class));
+  }
+
+  @Test
+  public void password_가_없어도_인증을_시도한다() throws Exception {
+    // given
+    Map<String, String> body = new HashMap<>();
+    body.put("email", "duk9741@gmail.com");
+
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setMethod("POST");
+    request.setContent(objectMapper.writeValueAsBytes(body));
+
+    // when
+    jsonLoginProcessingFilter.attemptAuthentication(request, response);
+
+    // then
+    verify(authenticationManager).authenticate(any(Authentication.class));
+  }
+
+}

--- a/src/test/java/me/coonect/coonect/common/security/login/handler/JwtAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/me/coonect/coonect/common/security/login/handler/JwtAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,70 @@
+package me.coonect.coonect.common.security.login.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import me.coonect.coonect.common.jwt.application.service.JwtProperties;
+import me.coonect.coonect.common.jwt.application.service.JwtService;
+import me.coonect.coonect.mock.FakeRefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JwtAuthenticationSuccessHandlerTest {
+
+  private JwtAuthenticationSuccessHandler jwtAuthenticationSuccessHandler;
+
+  private JwtProperties jwtProperties;
+  private JwtService jwtService;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  public void init() {
+
+    jwtProperties = JwtProperties.builder()
+        .secret("qweasd")
+        .accessTokenExpirationSeconds(100L)
+        .refreshTokenExpirationSeconds(1000L)
+        .tokenType("Bearer")
+        .build();
+
+    jwtService = new JwtService(new FakeRefreshTokenRepository(), jwtProperties);
+
+    objectMapper = new ObjectMapper();
+
+    jwtAuthenticationSuccessHandler = new JwtAuthenticationSuccessHandler(
+        jwtService, objectMapper);
+
+  }
+
+  @Test
+  public void 로그인_성공_시_200_OK_응답을_보낸다() throws Exception {
+    // given
+    HttpServletRequest request = new MockHttpServletRequest();
+    HttpServletResponse response = new MockHttpServletResponse();
+    Authentication authentication = new TestingAuthenticationToken(User.builder()
+        .username("duk9741@gmail.com")
+        .password("123123")
+        .roles("USER")
+        .build(), null);
+
+    // when
+    jwtAuthenticationSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    response.getOutputStream();
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+
+  }
+
+
+}

--- a/src/test/java/me/coonect/coonect/docs/AuthApiTest.java
+++ b/src/test/java/me/coonect/coonect/docs/AuthApiTest.java
@@ -1,0 +1,117 @@
+package me.coonect.coonect.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import me.coonect.coonect.common.error.exception.ErrorCode;
+import me.coonect.coonect.global.RestDocsTestSupport;
+import me.coonect.coonect.member.application.domain.model.Member;
+import me.coonect.coonect.member.application.port.out.persistence.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebMvcTest(excludeFilters = @ComponentScan.Filter(
+    type = FilterType.ANNOTATION,
+    classes = RestController.class
+))
+public class AuthApiTest extends RestDocsTestSupport {
+
+  @MockBean
+  private MemberRepository memberRepository;
+
+
+  @Test
+  public void login_200() throws Exception {
+    // given
+    String rawPassword = "raw@password1";
+
+    Member member = Member.withEncodedPassword(1L,
+        "test@test.com",
+        PasswordEncoderFactories.createDelegatingPasswordEncoder().encode(rawPassword),
+        "nickname",
+        LocalDate.of(1995, 1, 10));
+
+    given(memberRepository.findByEmail(any())).willReturn(Optional.of(member));
+
+    // when
+    LoginRequest request = new LoginRequest("test@test.com", rawPassword);
+    // then
+
+    mockMvc.perform(post("/login")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+                requestFields(
+                    fieldWithPath("email")
+                        .type(STRING)
+                        .description("멤버 이메일"),
+                    fieldWithPath("password")
+                        .type(STRING)
+                        .description("멤버 패스워드")
+                ),
+                responseFields(
+                    fieldWithPath("tokenType")
+                        .type(STRING)
+                        .description("토큰 타입, Bearer로 고정"),
+                    fieldWithPath("accessToken")
+                        .type(STRING)
+                        .description("이용자 엑세스 토큰 값"),
+                    fieldWithPath("accessTokenExpiresIn")
+                        .type(NUMBER)
+                        .description("엑세스 토큰 만료 시간(초)"),
+                    fieldWithPath("refreshToken")
+                        .type(STRING)
+                        .description("이용자 리프레시 토큰 값"),
+                    fieldWithPath("refreshTokenExpiresIn")
+                        .type(NUMBER)
+                        .description("리프레시 토큰 만료 시간(초)")
+                )
+            )
+        );
+  }
+
+  @Test
+  public void login_401() throws Exception {
+    // given
+    given(memberRepository.findByEmail(any())).willReturn(Optional.empty());
+
+    LoginRequest request = new LoginRequest("test@test.com", "123123");
+    // when
+    // then
+
+    mockMvc.perform(post("/login")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_USERNAME_OR_PASSWORD.getCode()))
+        .andExpect(
+            jsonPath("$.message").value(ErrorCode.INVALID_USERNAME_OR_PASSWORD.getMessage()));
+  }
+
+  @Getter
+  @AllArgsConstructor
+  private class LoginRequest {
+
+    private String email;
+    private String password;
+  }
+}

--- a/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
+++ b/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
@@ -5,6 +5,7 @@ import static org.springframework.restdocs.snippet.Attributes.Attribute;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import me.coonect.coonect.common.security.configuration.SecurityConfiguration;
 import me.coonect.coonect.global.config.RestDocsConfiguration;
+import me.coonect.coonect.mock.FakeMemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -23,7 +24,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@Import({RestDocsConfiguration.class, SecurityConfiguration.class})
+@Import({RestDocsConfiguration.class, SecurityConfiguration.class, FakeMemberRepository.class})
 @ExtendWith(RestDocumentationExtension.class)
 public class RestDocsTestSupport {
 

--- a/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
+++ b/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
@@ -3,6 +3,7 @@ package me.coonect.coonect.global;
 import static org.springframework.restdocs.snippet.Attributes.Attribute;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
 import me.coonect.coonect.common.jwt.application.service.JwtProperties;
 import me.coonect.coonect.common.jwt.application.service.JwtService;
 import me.coonect.coonect.common.security.configuration.SecurityConfiguration;
@@ -16,14 +17,17 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.security.config.BeanIds;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.DelegatingFilterProxy;
 
 @Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -48,8 +52,14 @@ public class RestDocsTestSupport {
 
   @BeforeEach
   void setUp(final WebApplicationContext context,
-      final RestDocumentationContextProvider provider) {
+      final RestDocumentationContextProvider provider) throws ServletException {
+
+    DelegatingFilterProxy delegateProxyFilter = new DelegatingFilterProxy();
+    delegateProxyFilter.init(
+        new MockFilterConfig(context.getServletContext(), BeanIds.SPRING_SECURITY_FILTER_CHAIN));
+
     this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .addFilter(delegateProxyFilter)
         .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
         .alwaysDo(MockMvcResultHandlers.print())
         .alwaysDo(restDocs)

--- a/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
+++ b/src/test/java/me/coonect/coonect/global/RestDocsTestSupport.java
@@ -3,9 +3,12 @@ package me.coonect.coonect.global;
 import static org.springframework.restdocs.snippet.Attributes.Attribute;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import me.coonect.coonect.common.jwt.application.service.JwtProperties;
+import me.coonect.coonect.common.jwt.application.service.JwtService;
 import me.coonect.coonect.common.security.configuration.SecurityConfiguration;
 import me.coonect.coonect.global.config.RestDocsConfiguration;
 import me.coonect.coonect.mock.FakeMemberRepository;
+import me.coonect.coonect.mock.FakeRefreshTokenRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -24,7 +27,10 @@ import org.springframework.web.context.WebApplicationContext;
 
 @Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@Import({RestDocsConfiguration.class, SecurityConfiguration.class, FakeMemberRepository.class})
+@Import({RestDocsConfiguration.class,
+    SecurityConfiguration.class,
+    FakeMemberRepository.class,
+    JwtService.class, FakeRefreshTokenRepository.class, JwtProperties.class})
 @ExtendWith(RestDocumentationExtension.class)
 public class RestDocsTestSupport {
 

--- a/src/test/java/me/coonect/coonect/mock/FakeMemberRepository.java
+++ b/src/test/java/me/coonect/coonect/mock/FakeMemberRepository.java
@@ -3,6 +3,7 @@ package me.coonect.coonect.mock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import me.coonect.coonect.member.application.domain.model.Member;
 import me.coonect.coonect.member.application.port.out.persistence.MemberRepository;
 
@@ -14,6 +15,11 @@ public class FakeMemberRepository implements MemberRepository {
   @Override
   public boolean existsByEmail(String email) {
     return data.stream().anyMatch(member -> member.getEmail().equals(email));
+  }
+
+  @Override
+  public Optional<Member> findByEmail(String email) {
+    return data.stream().filter(member -> member.getEmail().equals(email)).findFirst();
   }
 
   @Override

--- a/src/test/java/me/coonect/coonect/mock/FakeRefreshTokenRepository.java
+++ b/src/test/java/me/coonect/coonect/mock/FakeRefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package me.coonect.coonect.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import me.coonect.coonect.common.jwt.application.port.out.persistence.RefreshTokenRepository;
+
+public class FakeRefreshTokenRepository implements RefreshTokenRepository {
+
+  private Map<String, String> data = new HashMap<>();
+
+  @Override
+  public void update(String username, String refreshToken) {
+    data.put(username, refreshToken);
+  }
+
+  @Override
+  public Optional<String> find(String username) {
+    return Optional.ofNullable(data.get(username));
+  }
+}


### PR DESCRIPTION
## 작업 내용

- Spring Security 로그인 JWT 필터 구현

## 핵심 변경 사항

- 로그인 요청 성공 시 access token 발급
- 로그인 요청 성공 시 refresh token 저장 및 발급

## 테스트 결과

- 테스트 89개 중 89개 성공

<!-- 테스트 결과를 첨부해 주세요 -->
<img width="323" alt="image" src="https://github.com/coonect-projects/coonect-api/assets/59705184/20517395-10a1-4a28-82e2-fe4f6a858ca5">

- 클래스 커버리지 100% 달성
- 메서드 커버리지 87% 달성
- 라인 커버리지 87% 달성

<img width="320" alt="image" src="https://github.com/coonect-projects/coonect-api/assets/59705184/2c631450-2547-4a5a-a6b4-332c622fdf62">

## 닫힌 이슈

close #14

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
