### PR TITLE
JWT 인증 구현

### DIFF
--- a/src/main/java/me/coonect/coonect/common/error/exception/ErrorCode.java
+++ b/src/main/java/me/coonect/coonect/common/error/exception/ErrorCode.java
@@ -17,14 +17,22 @@ public enum ErrorCode {
   // Common
   INVALID_TYPE_VALUE(SC_BAD_REQUEST, "C-001", "Invalid Type Value"),
   INVALID_INPUT_VALUE(SC_BAD_REQUEST, "C-002", "Invalid Input Value"),
+  UNAUTHORIZED(SC_UNAUTHORIZED, "C-006", "Unauthorized"),
 
   // Authentication
   INVALID_USERNAME_OR_PASSWORD(SC_UNAUTHORIZED, "A-001", "Invalid Username or Password"),
+  TOKEN_EXPIRED(SC_UNAUTHORIZED, "A-002", "Token Expired"),
+  INVALID_TOKEN(SC_UNAUTHORIZED, "A-003", "Invalid Token"),
+
 
   // Business
   DUPLICATE(SC_CONFLICT, "B-001", "Duplicated Value"),
   NOT_FOUND(SC_NOT_FOUND, "B-002", "Entity Not Found"),
   MAIL_DELIVERY_ERROR(SC_BAD_REQUEST, "B-003", "Mail Delivery Error"),
+
+  // Secure
+  UNEXPECTED_REFRESH_TOKEN(SC_UNAUTHORIZED, "S-001",
+      "Unexpected Refresh Token. Connection From Another Location"),
 
   // Member
   EMAIL_DUPLICATE(SC_CONFLICT, "M-001", "Duplicate Email Address"),

--- a/src/main/java/me/coonect/coonect/common/jwt/adapter/out/persistence/RefreshTokenRedisRepository.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/adapter/out/persistence/RefreshTokenRedisRepository.java
@@ -26,4 +26,9 @@ public class RefreshTokenRedisRepository implements RefreshTokenRepository {
     return Optional.ofNullable(ops.get(KEY_PREFIX + username));
   }
 
+  @Override
+  public void delete(String username) {
+    redisTemplate.delete(KEY_PREFIX + username);
+  }
+
 }

--- a/src/main/java/me/coonect/coonect/common/jwt/application/port/out/persistence/RefreshTokenRepository.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/port/out/persistence/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository {
   void update(String username, String refreshToken);
 
   Optional<String> find(String username);
+
+  void delete(String username);
 }

--- a/src/main/java/me/coonect/coonect/common/jwt/application/service/JwtService.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/service/JwtService.java
@@ -90,7 +90,7 @@ public class JwtService {
 
   public Authentication resolveAccessToken(String accessToken) {
     Algorithm algorithm = Algorithm.HMAC256(jwtProperties.getSecret());
-    JWTVerifier verifier = JWT.require(algorithm).build();
+    JWTVerifier verifier = JWT.require(algorithm).withSubject(ACCESS_TOKEN_SUBJECT).build();
     DecodedJWT decodeToken = verifier.verify(accessToken);
 
     String username = decodeToken.getClaim(USERNAME_CLAIM).asString();

--- a/src/main/java/me/coonect/coonect/common/jwt/application/service/TokenResponse.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/service/TokenResponse.java
@@ -26,6 +26,11 @@ public class TokenResponse {
     send(response, objectMapper, HttpServletResponse.SC_OK);
   }
 
+  public void sendReissueResponse(HttpServletResponse response, ObjectMapper objectMapper)
+      throws IOException {
+    send(response, objectMapper, HttpServletResponse.SC_RESET_CONTENT);
+  }
+
   private void send(HttpServletResponse response, ObjectMapper objectMapper, int status)
       throws IOException {
     String body = objectMapper.writeValueAsString(this);

--- a/src/main/java/me/coonect/coonect/common/jwt/application/service/TokenResponse.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/application/service/TokenResponse.java
@@ -1,9 +1,17 @@
 package me.coonect.coonect.common.jwt.application.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.MediaType;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class TokenResponse {
 
@@ -13,4 +21,18 @@ public class TokenResponse {
   private String refreshToken;
   private Long refreshTokenExpiresIn;
 
+  public void sendLoginResponse(HttpServletResponse response, ObjectMapper objectMapper)
+      throws IOException {
+    send(response, objectMapper, HttpServletResponse.SC_OK);
+  }
+
+  private void send(HttpServletResponse response, ObjectMapper objectMapper, int status)
+      throws IOException {
+    String body = objectMapper.writeValueAsString(this);
+
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.getWriter().write(body);
+    response.setStatus(status);
+  }
 }

--- a/src/main/java/me/coonect/coonect/common/jwt/exception/UnexpectedRefreshTokenException.java
+++ b/src/main/java/me/coonect/coonect/common/jwt/exception/UnexpectedRefreshTokenException.java
@@ -1,0 +1,11 @@
+package me.coonect.coonect.common.jwt.exception;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+
+public class UnexpectedRefreshTokenException extends JWTVerificationException {
+
+  public UnexpectedRefreshTokenException() {
+    super("Connect From Another Location");
+  }
+}
+

--- a/src/main/java/me/coonect/coonect/common/security/authentication/entrypoint/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/me/coonect/coonect/common/security/authentication/entrypoint/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,63 @@
+package me.coonect.coonect.common.security.authentication.entrypoint;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.coonect.coonect.common.error.ErrorResponse;
+import me.coonect.coonect.common.error.exception.ErrorCode;
+import me.coonect.coonect.common.jwt.exception.UnexpectedRefreshTokenException;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+    JWTVerificationException jwtVerificationException =
+        (JWTVerificationException) request.getAttribute("exception");
+
+    if (jwtVerificationException instanceof TokenExpiredException) {
+      sendErrorResponse(response, ErrorCode.TOKEN_EXPIRED, 499);
+      return;
+    }
+
+    if (jwtVerificationException instanceof UnexpectedRefreshTokenException) {
+      sendErrorResponse(response, ErrorCode.UNEXPECTED_REFRESH_TOKEN,
+          HttpServletResponse.SC_UNAUTHORIZED);
+      return;
+    }
+
+    if (jwtVerificationException != null) {
+      sendErrorResponse(response, ErrorCode.INVALID_TOKEN, HttpServletResponse.SC_UNAUTHORIZED);
+      return;
+    }
+
+    sendErrorResponse(response, ErrorCode.UNAUTHORIZED, HttpServletResponse.SC_UNAUTHORIZED);
+  }
+
+  private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode, int status)
+      throws IOException {
+    ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+
+    String body = objectMapper.writeValueAsString(errorResponse);
+    response.setStatus(status);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.getWriter().write(body);
+  }
+
+}

--- a/src/main/java/me/coonect/coonect/common/security/authentication/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/me/coonect/coonect/common/security/authentication/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,91 @@
+package me.coonect.coonect.common.security.authentication.filter;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.coonect.coonect.common.jwt.application.service.JwtProperties;
+import me.coonect.coonect.common.jwt.application.service.JwtService;
+import me.coonect.coonect.common.jwt.application.service.TokenResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+  private final static String accessTokenHeaderName = "Authorization";
+  private final static String refreshTokenHeaderName = "Refresh-Token";
+
+  private final JwtService jwtService;
+  private final JwtProperties jwtProperties;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  /**
+   * 요청 Refresh-Token 헤더에 값이 존재하면 재발급 요청이라고 가정하고 재발급 프로세스를 진행한다.
+   * Refresh-Token 헤더가 존재하지 않으면 인증 요청이므로 인증 프로세스를 진핸한다.
+   */
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String refreshToken = extractRefreshToken(request);
+    String accessToken = extractAccessToken(request);
+
+    // refresh token 포함 재발급의 경우
+    if (StringUtils.hasText(refreshToken)) {
+      try {
+        TokenResponse tokenResponse = jwtService.reissue(refreshToken);
+        tokenResponse.sendReissueResponse(response, objectMapper);
+        return;
+      } catch (JWTVerificationException e) {
+        request.setAttribute("exception", e);
+      }
+
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    // access-token 없으면 pass
+    if (!StringUtils.hasText(accessToken)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    try {
+      Authentication authentication = jwtService.resolveAccessToken(accessToken);
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    } catch (JWTVerificationException e) {
+      // 인증이 실패했을 경우 request에 예외 저장
+      request.setAttribute("exception", e);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String extractRefreshToken(HttpServletRequest request) {
+    return extractToken(request, refreshTokenHeaderName);
+  }
+
+  private String extractAccessToken(HttpServletRequest request) {
+    return extractToken(request, accessTokenHeaderName);
+  }
+
+  private String extractToken(HttpServletRequest request, String headerName) {
+    String refreshTokenWithType = request.getHeader(headerName);
+
+    if (!StringUtils.hasText(refreshTokenWithType) ||
+        !refreshTokenWithType.startsWith(jwtProperties.getTokenType() + " ")) {
+      return null;
+    }
+    return refreshTokenWithType.substring(jwtProperties.getTokenType().length() + 1);
+  }
+
+}

--- a/src/main/java/me/coonect/coonect/common/security/login/handler/JwtAuthenticationSuccessHandler.java
+++ b/src/main/java/me/coonect/coonect/common/security/login/handler/JwtAuthenticationSuccessHandler.java
@@ -4,13 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.coonect.coonect.common.jwt.application.service.JwtService;
 import me.coonect.coonect.common.jwt.application.service.TokenResponse;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -32,11 +29,7 @@ public class JwtAuthenticationSuccessHandler implements AuthenticationSuccessHan
         .toList();
 
     TokenResponse tokenResponse = jwtService.generateTokens(username, roles);
-    String body = objectMapper.writeValueAsString(tokenResponse);
 
-    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-    response.getWriter().write(body);
-    response.setStatus(HttpStatus.OK.value());
+    tokenResponse.sendLoginResponse(response, objectMapper);
   }
 }

--- a/src/test/java/me/coonect/coonect/common/security/authentication/entrypoint/JwtAuthenticationEntryPointTest.java
+++ b/src/test/java/me/coonect/coonect/common/security/authentication/entrypoint/JwtAuthenticationEntryPointTest.java
@@ -1,0 +1,88 @@
+package me.coonect.coonect.common.security.authentication.entrypoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import me.coonect.coonect.common.jwt.exception.UnexpectedRefreshTokenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JwtAuthenticationEntryPointTest {
+
+  private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+  @BeforeEach
+  public void init() {
+    jwtAuthenticationEntryPoint = new JwtAuthenticationEntryPoint(new ObjectMapper());
+  }
+
+  @Test
+  public void 토큰이_만료되었다면_499_응답을_보낸다() throws Exception {
+    // given
+    HttpServletRequest request = new MockHttpServletRequest();
+    HttpServletResponse response = new MockHttpServletResponse();
+    request.setAttribute("exception", new TokenExpiredException("", null));
+
+    // when
+    jwtAuthenticationEntryPoint.commence(request, response,
+        new AuthenticationCredentialsNotFoundException(""));
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(499);
+  }
+
+  @Test
+  public void 요청_refresh_token_과_저장된_refresh_token_이_다르면_401_응답을_보낸다() throws Exception {
+    // given
+    HttpServletRequest request = new MockHttpServletRequest();
+    HttpServletResponse response = new MockHttpServletResponse();
+    request.setAttribute("exception", new UnexpectedRefreshTokenException());
+
+    // when
+    jwtAuthenticationEntryPoint.commence(request, response,
+        new AuthenticationCredentialsNotFoundException(""));
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(401);
+  }
+
+  @Test
+  public void 토큰_문제로_commence_된_것이라면_401_응답을_보낸다() throws Exception {
+    // given
+    HttpServletRequest request = new MockHttpServletRequest();
+    HttpServletResponse response = new MockHttpServletResponse();
+    request.setAttribute("exception", new JWTVerificationException("", null));
+
+    // when
+    jwtAuthenticationEntryPoint.commence(request, response,
+        new AuthenticationCredentialsNotFoundException(""));
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(401);
+  }
+
+  @Test
+  public void 토큰_외의_문제로_commence_된_것이라면_401_응답을_보낸다() throws Exception {
+    // given
+    HttpServletRequest request = new MockHttpServletRequest();
+    HttpServletResponse response = new MockHttpServletResponse();
+
+    // when
+    jwtAuthenticationEntryPoint.commence(request, response,
+        new AuthenticationCredentialsNotFoundException(""));
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(401);
+  }
+
+}

--- a/src/test/java/me/coonect/coonect/common/security/authentication/filter/JwtAuthenticationProcessingFilterTest.java
+++ b/src/test/java/me/coonect/coonect/common/security/authentication/filter/JwtAuthenticationProcessingFilterTest.java
@@ -210,7 +210,7 @@ class JwtAuthenticationProcessingFilterTest {
   @Test
   public void Access_Token_이_만료되었다면_request_에_exception_을_저장한다() throws Exception {
     // given
-    String accessToken = JWT.create().withSubject("refresh-token")
+    String accessToken = JWT.create().withSubject("access-token")
         .withIssuedAt(new Date(System.currentTimeMillis()))
         .withExpiresAt(new Date(System.currentTimeMillis() - 1000L))
         .withClaim("email", "duk9741@gmail.com")
@@ -239,7 +239,7 @@ class JwtAuthenticationProcessingFilterTest {
   @Test
   public void 잘못된_Secret_의_Access_Token_이라면_request_에_exception_을_저장한다() throws Exception {
     // given
-    String accessToken = JWT.create().withSubject("refresh-token")
+    String accessToken = JWT.create().withSubject("access-token")
         .withIssuedAt(new Date(System.currentTimeMillis()))
         .withExpiresAt(new Date(System.currentTimeMillis() - 1000L))
         .withClaim("email", "duk9741@gmail.com")

--- a/src/test/java/me/coonect/coonect/common/security/authentication/filter/JwtAuthenticationProcessingFilterTest.java
+++ b/src/test/java/me/coonect/coonect/common/security/authentication/filter/JwtAuthenticationProcessingFilterTest.java
@@ -1,0 +1,286 @@
+package me.coonect.coonect.common.security.authentication.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Date;
+import java.util.List;
+import me.coonect.coonect.common.jwt.application.port.out.persistence.RefreshTokenRepository;
+import me.coonect.coonect.common.jwt.application.service.JwtProperties;
+import me.coonect.coonect.common.jwt.application.service.JwtService;
+import me.coonect.coonect.common.jwt.application.service.TokenResponse;
+import me.coonect.coonect.common.jwt.exception.UnexpectedRefreshTokenException;
+import me.coonect.coonect.mock.FakeRefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JwtAuthenticationProcessingFilterTest {
+
+  private JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter;
+
+  private JwtProperties jwtProperties;
+
+  private JwtService jwtService;
+  private RefreshTokenRepository refreshTokenRepository;
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  public void init() {
+    SecurityContextHolder.clearContext();
+
+    jwtProperties = new JwtProperties(
+        "qweasd",
+        100L,
+        200L,
+        "Bearer"
+    );
+
+    refreshTokenRepository = new FakeRefreshTokenRepository();
+
+    jwtService = new JwtService(refreshTokenRepository, jwtProperties);
+
+    objectMapper = new ObjectMapper();
+
+    jwtAuthenticationProcessingFilter
+        = new JwtAuthenticationProcessingFilter(jwtService, jwtProperties, objectMapper);
+
+  }
+
+  @Test
+  public void Refresh_Token_이_헤더에_존재하면_RESET_CONTENT_응답과_Token_들을_모두_재발급_한다() throws Exception {
+    // given
+    // refresh token 저장
+    jwtService.generateTokens("duk9741@gmail.com", List.of("MEMBER"));
+    String refreshToken = refreshTokenRepository.find("duk9741@gmail.com").get();
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Refresh-Token", "Bearer " + refreshToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain, times(0)).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_RESET_CONTENT);
+
+    TokenResponse tokenResponse = objectMapper.readValue(response.getContentAsString(),
+        TokenResponse.class);
+
+    assertThat(tokenResponse).isNotNull();
+    assertThat(tokenResponse.getAccessToken()).isNotNull();
+    assertThat(tokenResponse.getRefreshToken()).isNotNull();
+    assertThat(tokenResponse.getAccessTokenExpiresIn()).isEqualTo(100L);
+    assertThat(tokenResponse.getRefreshTokenExpiresIn()).isEqualTo(200L);
+
+  }
+
+  @Test
+  public void Refresh_Token_이_저장된_것과_다르면_request_에_exception_을_저장한다() throws Exception {
+    // given
+    // refresh token 저장
+    jwtService.generateTokens("duk9741@gmail.com", List.of("MEMBER"));
+    String refreshToken = JWT.create().withSubject("refresh-token")
+        .withIssuedAt(new Date(System.currentTimeMillis()))
+        .withExpiresAt(new Date(System.currentTimeMillis()
+            + jwtProperties.getRefreshTokenExpirationSeconds() * 1000L + 1000))
+        .withClaim("email", "duk9741@gmail.com")
+        .withClaim("roles", "MEMBER")
+        .sign(Algorithm.HMAC256(jwtProperties.getSecret()));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Refresh-Token", "Bearer " + refreshToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(request.getAttribute("exception")).isInstanceOf(
+        UnexpectedRefreshTokenException.class);
+    assertThat(response.getContentLength()).isEqualTo(0);
+
+  }
+
+  @Test
+  public void Refresh_Token_이_만료_되었다면_request_에_exception_을_저장한다() throws Exception {
+    // given
+    String refreshToken = JWT.create().withSubject("refresh-token")
+        .withIssuedAt(new Date(System.currentTimeMillis()))
+        .withExpiresAt(new Date(System.currentTimeMillis() - 1000L))
+        .withClaim("email", "duk9741@gmail.com")
+        .withClaim("roles", "MEMBER")
+        .sign(Algorithm.HMAC256(jwtProperties.getSecret()));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Refresh-Token", "Bearer " + refreshToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(request.getAttribute("exception")).isInstanceOf(
+        TokenExpiredException.class);
+    assertThat(response.getContentLength()).isEqualTo(0);
+
+  }
+
+  @Test
+  public void 잘못된_Secret_의_Refresh_Token_이라면_request_에_exception_을_저장한다() throws Exception {
+    // given
+    String refreshToken = JWT.create().withSubject("refresh-token")
+        .withIssuedAt(new Date(System.currentTimeMillis()))
+        .withExpiresAt(new Date(System.currentTimeMillis() - 1000L))
+        .withClaim("email", "duk9741@gmail.com")
+        .withClaim("roles", "MEMBER")
+        .sign(Algorithm.HMAC256("xxxxxxxxxxxx"));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Refresh-Token",
+        "Bearer " + refreshToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(request.getAttribute("exception")).isInstanceOf(
+        JWTVerificationException.class);
+    assertThat(response.getContentLength()).isEqualTo(0);
+
+  }
+
+
+  @Test
+  public void Access_Token_이_헤더에_존재하면_SecurityContext_에_인증_객체를_저장한다() throws Exception {
+    // given
+    TokenResponse tokenResponse = jwtService.generateTokens("duk9741@gmail.com",
+        List.of("MEMBER"));
+    String accessToken = tokenResponse.getAccessToken();
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + accessToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    assertThat(response.getContentLength()).isEqualTo(0);
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+    assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+        .isEqualTo("duk9741@gmail.com");
+
+  }
+
+  @Test
+  public void Access_Token_이_만료되었다면_request_에_exception_을_저장한다() throws Exception {
+    // given
+    String accessToken = JWT.create().withSubject("refresh-token")
+        .withIssuedAt(new Date(System.currentTimeMillis()))
+        .withExpiresAt(new Date(System.currentTimeMillis() - 1000L))
+        .withClaim("email", "duk9741@gmail.com")
+        .withClaim("roles", "MEMBER")
+        .sign(Algorithm.HMAC256(jwtProperties.getSecret()));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + accessToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(request.getAttribute("exception")).isInstanceOf(
+        TokenExpiredException.class);
+    assertThat(
+        response.containsHeader("Refresh-Token")).isFalse();
+    assertThat(response.containsHeader("Authorization")).isFalse();
+
+  }
+
+  @Test
+  public void 잘못된_Secret_의_Access_Token_이라면_request_에_exception_을_저장한다() throws Exception {
+    // given
+    String accessToken = JWT.create().withSubject("refresh-token")
+        .withIssuedAt(new Date(System.currentTimeMillis()))
+        .withExpiresAt(new Date(System.currentTimeMillis() - 1000L))
+        .withClaim("email", "duk9741@gmail.com")
+        .withClaim("roles", "MEMBER")
+        .sign(Algorithm.HMAC256("xxxxxxxxxxxx"));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization",
+        "Bearer " + accessToken);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(request.getAttribute("exception")).isInstanceOf(
+        JWTVerificationException.class);
+    assertThat(response.getContentLength()).isEqualTo(0);
+
+  }
+
+  @Test
+  public void 토큰이_모두_존재하지_않는다면_필터를_지나간다() throws Exception {
+    // given
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = mock(FilterChain.class);
+
+    // when
+    jwtAuthenticationProcessingFilter.doFilterInternal(request, response, chain);
+
+    // then
+    verify(chain, times(1)).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    assertThat(request.getAttribute("exception")).isNull();
+    assertThat(response.getContentLength()).isEqualTo(0);
+  }
+
+
+}

--- a/src/test/java/me/coonect/coonect/mock/FakeRefreshTokenRepository.java
+++ b/src/test/java/me/coonect/coonect/mock/FakeRefreshTokenRepository.java
@@ -18,4 +18,9 @@ public class FakeRefreshTokenRepository implements RefreshTokenRepository {
   public Optional<String> find(String username) {
     return Optional.ofNullable(data.get(username));
   }
+
+  @Override
+  public void delete(String username) {
+    data.remove(username);
+  }
 }


### PR DESCRIPTION
## 작업 내용

- JWT 인증 구현
- JWT 토큰 재발급 구현

## 핵심 변경 사항

- `Authorization` 헤더에 access token을 담아서 인증 할 수 있음
- `Refresh-Token` 헤더에 refresh token을 담아서 재발급을 요청할 수 있음
- 발급한 refresh token과 요청한 refresh token이 다르면 에러 발생

## 테스트 결과

- 테스트 101개 중 101개 성공

![image](https://github.com/coonect-projects/coonect-api/assets/59705184/4dfa9e5c-c504-4427-b43a-4cd5a9d83e8a)

- 클래스 커버리지 100% 달성
- 메서드 커버리지 87% 달성
- 라인 커버리지 89% 달성

![image](https://github.com/coonect-projects/coonect-api/assets/59705184/4781ba10-10e6-4a15-ba8a-63c7251a3105)


## 닫힌 이슈

close #15 

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
